### PR TITLE
fix: Windows daemon + EBUSY test cleanup

### DIFF
--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -228,6 +228,7 @@ export async function startDetached(opts: { port?: number }): Promise<void> {
     stdout: logFd,
     stderr: logFd,
     stdin: "ignore",
+    detached: true,
     env: { ...process.env },
   });
   closeSync(logFd);

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -278,7 +278,7 @@ export async function watchCommand(opts: { daemon?: boolean }): Promise<void> {
       }
     }
 
-    for (const s of sinks) s.close();
+    await Promise.all(sinks.map(s => s.close().catch(() => {})));
     store.close();
     cleanup();
     process.exit(0);

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -47,7 +47,8 @@ export async function watchCommand(opts: { daemon?: boolean }): Promise<void> {
   }
 
   // Foreground mode: error if daemon is already running
-  if (isRunning()) {
+  // Skip check if we ARE the daemon (spawned by daemonize() which already wrote our PID)
+  if (!process.env.JIN_DAEMON && isRunning()) {
     const pid = readFileSync(PID_FILE, "utf-8").trim();
     console.log(`  jin is already running (PID ${pid}). Stop it first with \`jin stop\`.`);
     process.exit(1);
@@ -297,6 +298,7 @@ async function daemonize(): Promise<void> {
     stdout: logFd,
     stderr: logFd,
     stdin: "ignore",
+    detached: true,
     env: { ...process.env, JIN_DAEMON: "1" },
   });
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -257,12 +257,27 @@ export async function watchCommand(opts: { daemon?: boolean }): Promise<void> {
     if (pendingPush.size > 0) schedulePush();
   }, periodicInterval);
 
-  // Graceful shutdown
-  const shutdown = () => {
+  // Graceful shutdown — flush pending sink data before exit
+  let shuttingDown = false;
+  const shutdown = async () => {
+    if (shuttingDown) return; // prevent re-entry from second signal
+    shuttingDown = true;
     log("Shutting down...");
     if (pushTimer) clearTimeout(pushTimer);
     clearInterval(periodicTimer);
     watcher.close();
+
+    // Flush any pending sink pushes before closing
+    if (sinks.length > 0 && pendingPush.size > 0) {
+      const ids = new Set(pendingPush);
+      pendingPush.clear();
+      try {
+        await pushToSinks(store, sinks, ids, config, log);
+      } catch (err) {
+        log(`Flush error during shutdown: ${err}`);
+      }
+    }
+
     for (const s of sinks) s.close();
     store.close();
     cleanup();

--- a/src/store.ts
+++ b/src/store.ts
@@ -750,6 +750,8 @@ export class Store {
   }
 
   close(): void {
+    // Checkpoint WAL before closing so Windows releases the memory-mapped .db-shm file
+    try { this.db.exec("PRAGMA wal_checkpoint(TRUNCATE)"); } catch {}
     this.db.close();
   }
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -751,7 +751,9 @@ export class Store {
 
   close(): void {
     // Checkpoint WAL before closing so Windows releases the memory-mapped .db-shm file
-    try { this.db.exec("PRAGMA wal_checkpoint(TRUNCATE)"); } catch {}
+    try { this.db.exec("PRAGMA wal_checkpoint(TRUNCATE)"); } catch (e) {
+      if (process.env.DEBUG) console.warn("WAL checkpoint failed:", e);
+    }
     this.db.close();
   }
 }

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -171,6 +171,7 @@ async function restartRunning(mode: "service" | "daemon", log: (msg: string) => 
       stdout: logFd,
       stderr: logFd,
       stdin: "ignore",
+      detached: true,
       env: { ...process.env },
     });
     require("fs").closeSync(logFd);

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -172,7 +172,7 @@ async function restartRunning(mode: "service" | "daemon", log: (msg: string) => 
       stderr: logFd,
       stdin: "ignore",
       detached: true,
-      env: { ...process.env },
+      env: { ...process.env, JIN_DAEMON: "1" },
     });
     require("fs").closeSync(logFd);
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -126,10 +126,11 @@ export function createTestEnv(): TestEnv {
     cleanup: () => {
       store.close();
       delete process.env.JIN_CONFIG_DIR;
-      // Windows holds SQLite mmap handles briefly after close; retry rmSync
-      for (let i = 0; i < 3; i++) {
+      // Windows holds SQLite mmap handles briefly after close; retry with backoff
+      const delays = [50, 100, 200, 400, 800];
+      for (let i = 0; i < delays.length; i++) {
         try { rmSync(dir, { recursive: true, force: true }); return; } catch {
-          if (i < 2) Bun.sleepSync(50);
+          if (i < delays.length - 1) Bun.sleepSync(delays[i]);
         }
       }
     },

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -126,7 +126,12 @@ export function createTestEnv(): TestEnv {
     cleanup: () => {
       store.close();
       delete process.env.JIN_CONFIG_DIR;
-      rmSync(dir, { recursive: true, force: true });
+      // Windows holds SQLite mmap handles briefly after close; retry rmSync
+      for (let i = 0; i < 3; i++) {
+        try { rmSync(dir, { recursive: true, force: true }); return; } catch {
+          if (i < 2) Bun.sleepSync(50);
+        }
+      }
     },
   };
 }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -92,7 +92,11 @@ afterAll(() => {
   process.env.HOME = origHome;
   delete process.env.CODEX_HOME;
   delete process.env.JIN_CONFIG_DIR;
-  rmSync(tmpHome, { recursive: true, force: true });
+  for (let i = 0; i < 3; i++) {
+    try { rmSync(tmpHome, { recursive: true, force: true }); break; } catch {
+      if (i < 2) Bun.sleepSync(50);
+    }
+  }
 });
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -92,9 +92,10 @@ afterAll(() => {
   process.env.HOME = origHome;
   delete process.env.CODEX_HOME;
   delete process.env.JIN_CONFIG_DIR;
-  for (let i = 0; i < 3; i++) {
+  const delays = [50, 100, 200, 400, 800];
+  for (let i = 0; i < delays.length; i++) {
     try { rmSync(tmpHome, { recursive: true, force: true }); break; } catch {
-      if (i < 2) Bun.sleepSync(50);
+      if (i < delays.length - 1) Bun.sleepSync(delays[i]);
     }
   }
 });

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -32,9 +32,10 @@ import type { JinConfig } from "../src/config";
 
 afterAll(() => {
   delete process.env.JIN_CONFIG_DIR;
-  for (let i = 0; i < 3; i++) {
+  const delays = [50, 100, 200, 400, 800];
+  for (let i = 0; i < delays.length; i++) {
     try { rmSync(tmpHome, { recursive: true, force: true }); break; } catch {
-      if (i < 2) Bun.sleepSync(50);
+      if (i < delays.length - 1) Bun.sleepSync(delays[i]);
     }
   }
 });

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -32,7 +32,11 @@ import type { JinConfig } from "../src/config";
 
 afterAll(() => {
   delete process.env.JIN_CONFIG_DIR;
-  rmSync(tmpHome, { recursive: true, force: true });
+  for (let i = 0; i < 3; i++) {
+    try { rmSync(tmpHome, { recursive: true, force: true }); break; } catch {
+      if (i < 2) Bun.sleepSync(50);
+    }
+  }
 });
 
 // ═════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- **Daemon dies on Windows**: `Bun.spawn` without `detached: true` ties the child to the parent's process group — Windows kills the child when the parent exits. Added `detached: true` to all daemon spawn calls (watcher, UI, updater).
- **Daemon self-detects as "already running"**: The parent writes the child's PID to the PID file before the child starts, so the child's foreground `isRunning()` check finds its own PID and exits. Skip the check when `JIN_DAEMON=1`.
- **SQLite WAL checkpoint on close**: Windows holds mmap handles on `.db-shm` files briefly after `db.close()`. Adding `PRAGMA wal_checkpoint(TRUNCATE)` before close releases them immediately.
- **Test cleanup EBUSY**: Retry `rmSync` with short delays in test cleanup to handle Windows file locking (39 pass → 79 pass).

## Test plan
- [x] `jin start` → `jin status` shows watcher running after 15+ seconds (was dying immediately)
- [x] `jin restart` works correctly
- [x] `bun test` passes 79/83 tests (remaining 3 are pre-existing Gemini CLI `homedir()` caching issue, 1 cascading)
- [x] Integration tests pass with `docker compose` (Postgres + S3)
- [ ] Verify no regression on macOS/Linux (`detached: true` and WAL checkpoint are safe cross-platform)

🤖 Generated with [Claude Code](https://claude.com/claude-code)