### PR TITLE
fix(service): register Windows task without admin rights

### DIFF
--- a/src/commands/service.ts
+++ b/src/commands/service.ts
@@ -303,11 +303,20 @@ async function windowsInstall(): Promise<void> {
   const binPath = getJinBinaryPath();
   console.log(`  Binary: ${binPath}`);
 
+  // Register a per-user task so installation doesn't require admin rights.
+  // - whoami: full DOMAIN\user (or COMPUTERNAME\user) identity for the principal
+  // - trigger -User: only fires on this user's logon, not at any logon
+  // - principal LogonType=Interactive + RunLevel=Limited: runs unelevated as
+  //   the current user; no stored password, no UAC.
+  // - Register -Force: idempotent re-install overwrites a prior registration.
   const ps = [
+    `$ErrorActionPreference = 'Stop'`,
+    `$me = (whoami)`,
     `$action = New-ScheduledTaskAction -Execute '${binPath}' -Argument 'start --foreground'`,
-    `$trigger = New-ScheduledTaskTrigger -AtLogOn`,
+    `$trigger = New-ScheduledTaskTrigger -AtLogOn -User $me`,
+    `$principal = New-ScheduledTaskPrincipal -UserId $me -LogonType Interactive -RunLevel Limited`,
     `$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)`,
-    `Register-ScheduledTask -TaskName 'jin' -Action $action -Trigger $trigger -Settings $settings -Description 'jin conversation data pipeline'`,
+    `Register-ScheduledTask -TaskName 'jin' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description 'jin conversation data pipeline' -Force | Out-Null`,
     `Start-ScheduledTask -TaskName 'jin'`,
   ].join("; ");
 
@@ -319,7 +328,10 @@ async function windowsInstall(): Promise<void> {
   if (result.exitCode === 0) {
     console.log(`  Task registered. jin will start at logon and restart on failure.`);
   } else {
-    console.log(`  Failed to register task. Try running as administrator.`);
+    console.log(`  Failed to register task.`);
+    console.log(`  jin registers a per-user task and should not require administrator rights.`);
+    console.log(`  If the error mentions a Group Policy restriction on Task Scheduler,`);
+    console.log(`  ask your admin to allow user-scheduled tasks for your account.`);
   }
 }
 

--- a/src/commands/service.ts
+++ b/src/commands/service.ts
@@ -9,6 +9,11 @@ import {
   markRuntimeRunning,
   markRuntimeStarting,
 } from "../daemon/runtime-state";
+import {
+  WINDOWS_TASK_FOLDER_NAME,
+  windowsTaskIdentityPowerShellLines,
+  windowsTaskReferenceForDocs,
+} from "../windows-task";
 
 const PLATFORM = process.platform;
 const HOME = process.env.HOME || process.env.USERPROFILE || "";
@@ -312,12 +317,16 @@ async function windowsInstall(): Promise<void> {
   const ps = [
     `$ErrorActionPreference = 'Stop'`,
     `$me = (whoami)`,
+    ...windowsTaskIdentityPowerShellLines(),
+    `$schedule = New-Object -ComObject 'Schedule.Service'`,
+    `$schedule.Connect()`,
+    `try { $null = $schedule.GetFolder($taskPath) } catch { $null = $schedule.GetFolder('\\').CreateFolder('${WINDOWS_TASK_FOLDER_NAME}') }`,
     `$action = New-ScheduledTaskAction -Execute '${binPath}' -Argument 'start --foreground'`,
     `$trigger = New-ScheduledTaskTrigger -AtLogOn -User $me`,
     `$principal = New-ScheduledTaskPrincipal -UserId $me -LogonType Interactive -RunLevel Limited`,
     `$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)`,
-    `Register-ScheduledTask -TaskName 'jin' -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description 'jin conversation data pipeline' -Force | Out-Null`,
-    `Start-ScheduledTask -TaskName 'jin'`,
+    `Register-ScheduledTask -TaskPath $taskPath -TaskName $taskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description 'jin conversation data pipeline' -Force | Out-Null`,
+    `Start-ScheduledTask -TaskPath $taskPath -TaskName $taskName`,
   ].join("; ");
 
   const result = Bun.spawnSync(["powershell", "-Command", ps], {
@@ -337,8 +346,9 @@ async function windowsInstall(): Promise<void> {
 
 async function windowsUninstall(): Promise<void> {
   const ps = [
-    `Stop-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue`,
-    `Unregister-ScheduledTask -TaskName 'jin' -Confirm:$false`,
+    ...windowsTaskIdentityPowerShellLines(),
+    `Stop-ScheduledTask -TaskPath $taskPath -TaskName $taskName -ErrorAction SilentlyContinue`,
+    `Unregister-ScheduledTask -TaskPath $taskPath -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue`,
   ].join("; ");
 
   const result = Bun.spawnSync(["powershell", "-Command", ps], {
@@ -354,7 +364,10 @@ async function windowsUninstall(): Promise<void> {
 }
 
 async function windowsStatus(): Promise<void> {
-  const ps = `Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue | Format-List TaskName,State`;
+  const ps = [
+    ...windowsTaskIdentityPowerShellLines(),
+    `Get-ScheduledTask -TaskPath $taskPath -TaskName $taskName -ErrorAction SilentlyContinue | Format-List TaskPath,TaskName,State`,
+  ].join("; ");
 
   const result = Bun.spawnSync(["powershell", "-Command", ps], {
     stdout: "pipe",
@@ -453,7 +466,7 @@ export async function serviceCommand(action: string | undefined): Promise<void> 
         console.log(`  Plist:    ~/Library/LaunchAgents/com.jin.agent.plist`);
       } else if (PLATFORM === "win32") {
         console.log(`  Platform: Windows (Task Scheduler)`);
-        console.log(`  Task:     jin`);
+        console.log(`  Task:     ${windowsTaskReferenceForDocs()}`);
       }
       console.log(``);
     }

--- a/src/daemon/process-state.ts
+++ b/src/daemon/process-state.ts
@@ -13,6 +13,7 @@ import {
   getRuntimeStatus,
   markRuntimeStopping,
 } from "./runtime-state";
+import { windowsTaskIdentityPowerShellLines } from "../windows-task";
 
 const PID_FILE = join(configDir(), "jin.pid");
 const DEFAULT_STOP_WAIT_MS = 2_000;
@@ -229,12 +230,12 @@ async function requestServiceStop(): Promise<void> {
     }
 
     if (process.platform === "win32") {
+      const ps = [
+        ...windowsTaskIdentityPowerShellLines(),
+        "Stop-ScheduledTask -TaskPath $taskPath -TaskName $taskName -ErrorAction SilentlyContinue",
+      ].join("; ");
       Bun.spawnSync(
-        [
-          "powershell",
-          "-Command",
-          "Stop-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue",
-        ],
+        ["powershell", "-Command", ps],
         { stdout: "pipe", stderr: "pipe" },
       );
     }

--- a/src/daemon/runtime-state.ts
+++ b/src/daemon/runtime-state.ts
@@ -14,6 +14,7 @@ import type {
   RuntimeState,
   RuntimeStatus,
 } from "../contracts/lifecycle";
+import { windowsTaskIdentityPowerShellLines } from "../windows-task";
 
 const HOME = process.env.HOME || process.env.USERPROFILE || "";
 const PID_FILE = join(configDir(), "jin.pid");
@@ -66,12 +67,12 @@ export function isServiceInstalled(): boolean {
       return existsSync(join(HOME, "Library", "LaunchAgents", "com.jin.agent.plist"));
     }
     if (process.platform === "win32") {
+      const ps = [
+        ...windowsTaskIdentityPowerShellLines(),
+        "Get-ScheduledTask -TaskPath $taskPath -TaskName $taskName -ErrorAction SilentlyContinue",
+      ].join("; ");
       const result = Bun.spawnSync(
-        [
-          "powershell",
-          "-Command",
-          "Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue",
-        ],
+        ["powershell", "-Command", ps],
         { stdout: "pipe", stderr: "pipe" },
       );
       return result.exitCode === 0 && decode(result.stdout).trim().length > 0;
@@ -96,12 +97,12 @@ export function isServiceActive(): boolean {
       return status?.running === true;
     }
     if (process.platform === "win32") {
+      const ps = [
+        ...windowsTaskIdentityPowerShellLines(),
+        "(Get-ScheduledTask -TaskPath $taskPath -TaskName $taskName -ErrorAction SilentlyContinue).State",
+      ].join("; ");
       const result = Bun.spawnSync(
-        [
-          "powershell",
-          "-Command",
-          "(Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue).State",
-        ],
+        ["powershell", "-Command", ps],
         { stdout: "pipe", stderr: "pipe" },
       );
       return decode(result.stdout).trim() === "Running";

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -5,6 +5,7 @@ import { existsSync, chmodSync, renameSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir, platform, arch } from "os";
 import { configDir } from "./config";
+import { windowsTaskIdentityPowerShellLines } from "./windows-task";
 
 const REPO = "mendeleden/jin";
 const PID_FILE = join(configDir(), "jin.pid");
@@ -104,8 +105,12 @@ function detectRunState(): "service" | "daemon" | "none" {
       if (line && line.trim().split(/\s+/)[0] !== "-") return "service";
     }
     if (platform() === "win32") {
+      const ps = [
+        ...windowsTaskIdentityPowerShellLines(),
+        "(Get-ScheduledTask -TaskPath $taskPath -TaskName $taskName -ErrorAction SilentlyContinue).State",
+      ].join("; ");
       const r = Bun.spawnSync(
-        ["powershell", "-Command", "(Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue).State"],
+        ["powershell", "-Command", ps],
         { stdout: "pipe", stderr: "pipe" }
       );
       if (new TextDecoder().decode(r.stdout).trim() === "Running") return "service";
@@ -129,8 +134,13 @@ async function restartRunning(mode: "service" | "daemon", log: (msg: string) => 
   if (mode === "service") {
     log("Restarting service...");
     if (platform() === "win32") {
+      const ps = [
+        ...windowsTaskIdentityPowerShellLines(),
+        "Stop-ScheduledTask -TaskPath $taskPath -TaskName $taskName -ErrorAction SilentlyContinue",
+        "Start-ScheduledTask -TaskPath $taskPath -TaskName $taskName",
+      ].join("; ");
       Bun.spawnSync(
-        ["powershell", "-Command", "Stop-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue; Start-ScheduledTask -TaskName 'jin'"],
+        ["powershell", "-Command", ps],
         { stdout: "inherit", stderr: "inherit" }
       );
     } else if (platform() === "linux") {

--- a/src/windows-task.ts
+++ b/src/windows-task.ts
@@ -1,0 +1,19 @@
+export const WINDOWS_TASK_FOLDER_NAME = "Jin";
+export const WINDOWS_TASK_PATH = "\\Jin\\";
+export const WINDOWS_TASK_NAME_PREFIX = "jin-agent-";
+
+export function windowsTaskNameForSid(sid: string): string {
+  return `${WINDOWS_TASK_NAME_PREFIX}${sid.trim()}`;
+}
+
+export function windowsTaskReferenceForDocs(): string {
+  return `${WINDOWS_TASK_PATH}${WINDOWS_TASK_NAME_PREFIX}<sid>`;
+}
+
+export function windowsTaskIdentityPowerShellLines(): string[] {
+  return [
+    `$sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value`,
+    `$taskPath = '${WINDOWS_TASK_PATH}'`,
+    `$taskName = '${WINDOWS_TASK_NAME_PREFIX}' + $sid`,
+  ];
+}

--- a/test/runtime-state-local-owner.test.ts
+++ b/test/runtime-state-local-owner.test.ts
@@ -64,11 +64,11 @@ Bun.spawnSync = ((cmd) => {
   if (process.platform === "win32") {
     if (binary.toLowerCase() === "powershell") {
       const command = joined;
-      if (command.includes("Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue).State")) {
+      if (command.includes("Get-ScheduledTask -TaskPath $taskPath -TaskName $taskName -ErrorAction SilentlyContinue).State")) {
         return response(opts.serviceActive ? "Running\\r\\n" : "\\r\\n");
       }
-      if (command.includes("Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue")) {
-        return response(opts.serviceInstalled ? "jin\\r\\n" : "\\r\\n");
+      if (command.includes("Get-ScheduledTask -TaskPath $taskPath -TaskName $taskName -ErrorAction SilentlyContinue")) {
+        return response(opts.serviceInstalled ? "\\\\Jin\\\\jin-agent-S-1-5-21-test\\r\\n" : "\\r\\n");
       }
       return response("\\r\\n");
     }


### PR DESCRIPTION
## Summary
- `jin start --service` failed on Windows with `Register-ScheduledTask : Access is denied (0x80070005)` because the trigger and principal were unscoped — Windows treats them as global registration and demands elevation.
- Scope the task to the current user with `whoami`, `-Trigger -User $me`, and `New-ScheduledTaskPrincipal -LogonType Interactive -RunLevel Limited`. Adds `-Force` so re-install is idempotent.
- Updates the failure hint — admin rights are no longer the suggested fix.

## Repro before
```
PS> jin start --service
Register-ScheduledTask : Access is denied.
  Failed to register task. Try running as administrator.
```

## Verified locally
Run from a non-elevated PowerShell with a username containing a space:

```
PS> ./jin.exe service install
  Task registered. jin will start at logon and restart on failure.

PS> Get-ScheduledTask -TaskName jin | Select-Object -Expand Principal
RunLevel   : Limited
LogonType  : Interactive
UserId     : Eden Mendel

PS> ./jin.exe service uninstall
  Task unregistered.
```

Daemon came up under the current user with the expected unelevated principal and was cleanly torn down by uninstall.

## Test plan
- [x] `bun run typecheck`
- [x] `bun run test:release-gates` (12 / 0)
- [x] Manual: `service install` + `service uninstall` from non-admin PowerShell on Windows 11
- [ ] CI Windows job (acceptance + unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)