### PR TITLE
fix(windows): hide daemon child process windows

### DIFF
--- a/src/adapters/amp.ts
+++ b/src/adapters/amp.ts
@@ -311,12 +311,14 @@ export class AmpAdapter implements Adapter, V2Adapter {
       const remote = execFileSync("git", ["remote", "get-url", "origin"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();
       const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -1603,6 +1603,7 @@ export class ClaudeCodeAdapter implements ContractAdapter {
           cwd: resolvedCwd,
           encoding: "utf8",
           stdio: ["ignore", "pipe", "ignore"],
+          windowsHide: true,
         }).trim();
       } catch {
         return "";

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -889,11 +889,13 @@ export class CodexAdapter implements Adapter, V2Adapter {
         cwd,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       }).trim();
       const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
         cwd,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       }).trim();
       const result = { remote, branch };
       this.gitCache.set(cwd, result);

--- a/src/adapters/gemini-cli.ts
+++ b/src/adapters/gemini-cli.ts
@@ -339,12 +339,14 @@ export class GeminiCliAdapter implements Adapter, V2Adapter {
       const remote = execFileSync("git", ["remote", "get-url", "origin"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();
       const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();

--- a/src/adapters/kiro.ts
+++ b/src/adapters/kiro.ts
@@ -357,12 +357,14 @@ export class KiroAdapter implements Adapter, V2Adapter {
       const remote = execFileSync("git", ["remote", "get-url", "origin"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();
       const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -284,12 +284,14 @@ export class OpenCodeAdapter implements Adapter, V2Adapter {
       const remote = execFileSync("git", ["remote", "get-url", "origin"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();
       const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();

--- a/src/adapters/pi.ts
+++ b/src/adapters/pi.ts
@@ -297,12 +297,14 @@ export class PiAdapter implements Adapter, V2Adapter {
       const remote = execFileSync("git", ["remote", "get-url", "origin"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();
       const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();

--- a/src/adapters/piagent.ts
+++ b/src/adapters/piagent.ts
@@ -297,12 +297,14 @@ export class PiAgentAdapter implements Adapter, V2Adapter {
       const remote = execFileSync("git", ["remote", "get-url", "origin"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();
       const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();

--- a/src/adapters/warp.ts
+++ b/src/adapters/warp.ts
@@ -323,12 +323,14 @@ export class WarpAdapter implements Adapter, V2Adapter {
       const remote = execFileSync("git", ["remote", "get-url", "origin"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();
       const branch = execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
         cwd,
         stdio: ["ignore", "pipe", "ignore"],
+        windowsHide: true,
       })
         .toString()
         .trim();

--- a/src/api/control.ts
+++ b/src/api/control.ts
@@ -150,6 +150,7 @@ async function executeLifecycleAction(
     stderr: "pipe",
     stdin: "ignore",
     env: { ...process.env },
+    windowsHide: true,
   });
 
   return {

--- a/src/commands/service.ts
+++ b/src/commands/service.ts
@@ -311,10 +311,14 @@ async function windowsInstall(): Promise<void> {
     `Start-ScheduledTask -TaskName 'jin'`,
   ].join("; ");
 
-  const result = Bun.spawnSync(["powershell", "-Command", ps], {
-    stdout: "inherit",
-    stderr: "inherit",
-  });
+  const result = Bun.spawnSync(
+    ["powershell", "-NoLogo", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", ps],
+    {
+      stdout: "inherit",
+      stderr: "inherit",
+      windowsHide: true,
+    },
+  );
 
   if (result.exitCode === 0) {
     console.log(`  Task registered. jin will start at logon and restart on failure.`);
@@ -329,10 +333,14 @@ async function windowsUninstall(): Promise<void> {
     `Unregister-ScheduledTask -TaskName 'jin' -Confirm:$false`,
   ].join("; ");
 
-  const result = Bun.spawnSync(["powershell", "-Command", ps], {
-    stdout: "inherit",
-    stderr: "inherit",
-  });
+  const result = Bun.spawnSync(
+    ["powershell", "-NoLogo", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", ps],
+    {
+      stdout: "inherit",
+      stderr: "inherit",
+      windowsHide: true,
+    },
+  );
 
   if (result.exitCode === 0) {
     console.log(`  Task unregistered.`);
@@ -344,10 +352,14 @@ async function windowsUninstall(): Promise<void> {
 async function windowsStatus(): Promise<void> {
   const ps = `Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue | Format-List TaskName,State`;
 
-  const result = Bun.spawnSync(["powershell", "-Command", ps], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+  const result = Bun.spawnSync(
+    ["powershell", "-NoLogo", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", ps],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+      windowsHide: true,
+    },
+  );
 
   const output = new TextDecoder().decode(result.stdout).trim();
   if (output) {

--- a/src/daemon/daemonize.ts
+++ b/src/daemon/daemonize.ts
@@ -32,6 +32,10 @@ export async function daemonize(): Promise<void> {
     stdin: "ignore",
     detached: true,
     env: { ...process.env, JIN_DAEMON: "1" },
+    // On Windows, suppress the console window for the detached daemon and any
+    // children it later spawns; without this each Bun.spawn from the daemon
+    // pops a conhost.exe window because the daemon has no inheritable console.
+    windowsHide: true,
   });
   closeSync(logFd);
 

--- a/src/daemon/process-state.ts
+++ b/src/daemon/process-state.ts
@@ -232,10 +232,14 @@ async function requestServiceStop(): Promise<void> {
       Bun.spawnSync(
         [
           "powershell",
+          "-NoLogo",
+          "-NonInteractive",
+          "-WindowStyle",
+          "Hidden",
           "-Command",
           "Stop-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue",
         ],
-        { stdout: "pipe", stderr: "pipe" },
+        { stdout: "pipe", stderr: "pipe", windowsHide: true },
       );
     }
   } catch {}

--- a/src/daemon/runtime-state.ts
+++ b/src/daemon/runtime-state.ts
@@ -22,6 +22,32 @@ const LOG_FILE = join(configDir(), "jin.log");
 const STARTING_GRACE_MS = 10_000;
 const decoder = new TextDecoder();
 
+// Run a powershell command without flashing a console window. Without
+// `windowsHide` + `-WindowStyle Hidden`, every probe pops a visible powershell
+// console because the daemon process has no inheritable console of its own.
+function runHiddenPowerShell(script: string): {
+  exitCode: number | null;
+  stdout: Uint8Array;
+  stderr: Uint8Array;
+} {
+  return Bun.spawnSync(
+    [
+      "powershell",
+      "-NoLogo",
+      "-NonInteractive",
+      "-WindowStyle",
+      "Hidden",
+      "-Command",
+      script,
+    ],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+      windowsHide: true,
+    },
+  );
+}
+
 export type RunMode = RuntimeMode | "none";
 
 interface PersistedRuntimeState {
@@ -66,13 +92,8 @@ export function isServiceInstalled(): boolean {
       return existsSync(join(HOME, "Library", "LaunchAgents", "com.jin.agent.plist"));
     }
     if (process.platform === "win32") {
-      const result = Bun.spawnSync(
-        [
-          "powershell",
-          "-Command",
-          "Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue",
-        ],
-        { stdout: "pipe", stderr: "pipe" },
+      const result = runHiddenPowerShell(
+        "Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue",
       );
       return result.exitCode === 0 && decode(result.stdout).trim().length > 0;
     }
@@ -96,13 +117,8 @@ export function isServiceActive(): boolean {
       return status?.running === true;
     }
     if (process.platform === "win32") {
-      const result = Bun.spawnSync(
-        [
-          "powershell",
-          "-Command",
-          "(Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue).State",
-        ],
-        { stdout: "pipe", stderr: "pipe" },
+      const result = runHiddenPowerShell(
+        "(Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue).State",
       );
       return decode(result.stdout).trim() === "Running";
     }

--- a/src/pipeline/ingest-worker.ts
+++ b/src/pipeline/ingest-worker.ts
@@ -274,6 +274,9 @@ export async function ingestConversationViaWorker(
     stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
+    // Suppress the new console window each worker would otherwise pop on
+    // Windows when the daemon parent has no inheritable console.
+    windowsHide: true,
   });
   const stderrPromise = readStreamText(subprocess.stderr);
   let session: ConversationWriteSession | null = null;
@@ -549,6 +552,9 @@ export async function findChangedViaWorker(
     stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
+    // Suppress the new console window each worker would otherwise pop on
+    // Windows when the daemon parent has no inheritable console.
+    windowsHide: true,
   });
   const stderrPromise = readStreamText(subprocess.stderr);
   let nextRequestId = 1;

--- a/src/tagger.ts
+++ b/src/tagger.ts
@@ -23,7 +23,7 @@ function projectNameFromCwd(cwd: string): string {
 /** Detect git remote origin URL from a directory (returns undefined if not a git repo) */
 function gitRemoteFromCwd(cwd: string): string | undefined {
   try {
-    return execSync("git remote get-url origin", { cwd, timeout: 3000, stdio: ["pipe", "pipe", "pipe"] })
+    return execSync("git remote get-url origin", { cwd, timeout: 3000, stdio: ["pipe", "pipe", "pipe"], windowsHide: true })
       .toString()
       .trim() || undefined;
   } catch {
@@ -34,7 +34,7 @@ function gitRemoteFromCwd(cwd: string): string | undefined {
 /** Detect current git branch from a directory */
 function gitBranchFromCwd(cwd: string): string | undefined {
   try {
-    return execSync("git rev-parse --abbrev-ref HEAD", { cwd, timeout: 3000, stdio: ["pipe", "pipe", "pipe"] })
+    return execSync("git rev-parse --abbrev-ref HEAD", { cwd, timeout: 3000, stdio: ["pipe", "pipe", "pipe"], windowsHide: true })
       .toString()
       .trim() || undefined;
   } catch {

--- a/src/types/bun-windows-hide.d.ts
+++ b/src/types/bun-windows-hide.d.ts
@@ -1,0 +1,12 @@
+// Bun.spawn supports `windowsHide` at runtime (it forwards to libuv's
+// CREATE_NO_WINDOW flag), but the Bun @types stub doesn't expose it. Without
+// it, every child process from a daemonized Bun parent on Windows pops a
+// conhost.exe window. Augment the type so call sites can pass the flag.
+declare module "bun" {
+  namespace Spawn {
+    interface BaseOptions<In extends Writable, Out extends Readable, Err extends Readable> {
+      windowsHide?: boolean;
+    }
+  }
+}
+export {};

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -105,8 +105,8 @@ function detectRunState(): "service" | "daemon" | "none" {
     }
     if (platform() === "win32") {
       const r = Bun.spawnSync(
-        ["powershell", "-Command", "(Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue).State"],
-        { stdout: "pipe", stderr: "pipe" }
+        ["powershell", "-NoLogo", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", "(Get-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue).State"],
+        { stdout: "pipe", stderr: "pipe", windowsHide: true } as Parameters<typeof Bun.spawnSync>[1],
       );
       if (new TextDecoder().decode(r.stdout).trim() === "Running") return "service";
     }
@@ -130,8 +130,8 @@ async function restartRunning(mode: "service" | "daemon", log: (msg: string) => 
     log("Restarting service...");
     if (platform() === "win32") {
       Bun.spawnSync(
-        ["powershell", "-Command", "Stop-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue; Start-ScheduledTask -TaskName 'jin'"],
-        { stdout: "inherit", stderr: "inherit" }
+        ["powershell", "-NoLogo", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", "Stop-ScheduledTask -TaskName 'jin' -ErrorAction SilentlyContinue; Start-ScheduledTask -TaskName 'jin'"],
+        { stdout: "inherit", stderr: "inherit", windowsHide: true } as Parameters<typeof Bun.spawnSync>[1],
       );
     } else if (platform() === "linux") {
       Bun.spawnSync(["systemctl", "--user", "restart", "jin.service"], { stdout: "inherit", stderr: "inherit" });

--- a/tools/serve-diagnostic.ts
+++ b/tools/serve-diagnostic.ts
@@ -1,9 +1,95 @@
+import { existsSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
+import { configDir } from "../src/config";
 
 const PORT = Number(process.env.PORT) || 3333;
 const HTML_PATH = join(import.meta.dir, "diagnostic-viewer.html");
-const DEBUG_LOG = process.env.JIN_DIAGNOSTIC_LOG || join(homedir(), ".config/jin/debug.jsonl");
+const DEBUG_LOG = resolveDiagnosticLogPath();
+
+type Candidate = {
+  path: string;
+  source: string;
+};
+
+function resolveDiagnosticLogPath(): Candidate {
+  const candidates = diagnosticLogCandidates();
+  return (
+    candidates.find((candidate) => existsSync(candidate.path)) ??
+    candidates[0] ?? {
+      path: join(configDir(), "debug.jsonl"),
+      source: "jin config dir",
+    }
+  );
+}
+
+function diagnosticLogCandidates(): Candidate[] {
+  if (process.env.JIN_DIAGNOSTIC_LOG) {
+    return [
+      {
+        path: process.env.JIN_DIAGNOSTIC_LOG,
+        source: "JIN_DIAGNOSTIC_LOG",
+      },
+    ];
+  }
+
+  const home = homedir();
+  const candidates: Candidate[] = [
+    {
+      path: join(configDir(), "debug.jsonl"),
+      source: "jin config dir",
+    },
+  ];
+
+  if (process.platform === "win32") {
+    candidates.push(
+      {
+        path: join(
+          process.env.LOCALAPPDATA || join(home, "AppData", "Local"),
+          "jin",
+          "debug.jsonl",
+        ),
+        source: "Windows LOCALAPPDATA",
+      },
+      {
+        path: join(
+          process.env.APPDATA || join(home, "AppData", "Roaming"),
+          "jin",
+          "debug.jsonl",
+        ),
+        source: "Windows APPDATA fallback",
+      },
+    );
+  } else {
+    candidates.push(
+      {
+        path: join(process.env.XDG_CONFIG_HOME || join(home, ".config"), "jin", "debug.jsonl"),
+        source: "XDG config",
+      },
+      {
+        path: join(home, ".config", "jin", "debug.jsonl"),
+        source: "home .config fallback",
+      },
+    );
+
+    if (process.platform === "darwin") {
+      candidates.push({
+        path: join(home, "Library", "Application Support", "jin", "debug.jsonl"),
+        source: "macOS Application Support fallback",
+      });
+    }
+  }
+
+  const seen = new Set<string>();
+  return candidates.filter((candidate) => {
+    const key = candidate.path.toLowerCase();
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
 
 Bun.serve({
   port: PORT,
@@ -20,7 +106,19 @@ Bun.serve({
     }
 
     if (url.pathname === "/debug.jsonl") {
-      return new Response(Bun.file(DEBUG_LOG), {
+      if (!existsSync(DEBUG_LOG.path)) {
+        const checked = diagnosticLogCandidates()
+          .map((candidate) => `- ${candidate.source}: ${candidate.path}`)
+          .join("\n");
+        return new Response(`debug log not found\nchecked:\n${checked}\n`, {
+          status: 404,
+          headers: {
+            "content-type": "text/plain",
+            "cache-control": "no-store",
+          },
+        });
+      }
+      return new Response(Bun.file(DEBUG_LOG.path), {
         headers: {
           "content-type": "application/x-ndjson",
           "access-control-allow-origin": "*",
@@ -34,4 +132,5 @@ Bun.serve({
 });
 
 console.log(`jin diagnostic viewer: http://localhost:${PORT}`);
-console.log(`reading: ${DEBUG_LOG}`);
+console.log(`reading: ${DEBUG_LOG.path}`);
+console.log(`source: ${DEBUG_LOG.source}`);


### PR DESCRIPTION
## Summary
- suppress Windows console popups from daemon/service/runtime spawn paths
- add  to daemon workers, lifecycle probes, and git probe helpers
- improve Windows diagnostic log path fallback for the diagnostic server

## Validation
- reviewed against 
- focused lifecycle/runtime tests passed in review
- native Windows smoke test confirmed the popup issue is fixed
