### PR TITLE
Harden config mutation reload boundary

### DIFF
--- a/.execution/program.md
+++ b/.execution/program.md
@@ -1,6 +1,6 @@
 # Jin Execution Program
 
-Updated: 2026-05-13
+Updated: 2026-05-14
 Branch: `fix/config-mutation-boundary-19`
 Focus: Config mutation boundary hardening after Desktop daemon IPC review.
 
@@ -12,7 +12,7 @@ Config-mutating CLI commands should not rely on indirect file watching as their 
 
 | Packet | Status | Owner | Purpose |
 | --- | --- | --- | --- |
-| W4-CONFIG-01 | approved | worker | Daemon local API route for config reload and command-side notification |
+| W4-CONFIG-01 | review_ready | worker | Daemon reload control plus current-config push cutover hardening |
 | W4-CONFIG-02 | queued | worker | Immutable reload/queue status snapshots for CLI and Desktop |
 
 ## Dependency Graph
@@ -23,6 +23,7 @@ flowchart TD
   BP08[BP-08 Routing and Config]
   ReloadPipeline[Current branch config-reload pipeline]
   W4C01[W4-CONFIG-01 Daemon reload control]
+  PushCutover[Current-config push cutover]
   W4C02[W4-CONFIG-02 Runtime reload and queue status]
   Desktop[Desktop daemon IPC]
   CLI[Config-mutating CLI commands]
@@ -30,6 +31,8 @@ flowchart TD
   BP07 --> W4C01
   BP08 --> W4C01
   ReloadPipeline --> W4C01
+  W4C01 --> PushCutover
+  BP08 --> PushCutover
   W4C01 --> CLI
   W4C01 --> W4C02
   BP07 --> W4C02
@@ -47,8 +50,9 @@ flowchart TD
 
 ## Latest Status
 
-- W4-CONFIG-01 implementation is complete, focused validation is green, and BP/code rechecks passed.
-- Resolved review findings: sink enable/disable no longer mutates runtime pause state directly, config mutations cross the local daemon reload boundary, startup/reload strict validation rejects malformed generations, fatal reload shutdown skips stale final-flush, active sink-disable checks at push batch boundaries, and route/sink help includes `--yes` parity.
+- W4-CONFIG-01 is review-ready after owner review follow-ups were patched and validated.
+- Resolved review findings: sink enable/disable no longer mutates runtime pause state directly, config mutations cross the local daemon reload boundary, startup/reload strict validation rejects malformed generations, fatal reload shutdown skips stale final-flush, and active sink-disable checks at push batch boundaries.
+- Current patch result: config mutations use `--restart` for explicit full recycle, sink health checks run outside the config lock, successful config reload enqueues push, and push batches re-check current config routes/sinks before egress plus avoid recording local success across generation changes.
 - W4-CONFIG-02 should land after W4-CONFIG-01 so status can preserve the accepted-vs-completed distinction.
 - Huygens completed read-only design review for W4-CONFIG-02; recommended queue/reload snapshot fields were copied into the packet.
 
@@ -57,4 +61,4 @@ flowchart TD
 - Packets and prompts exist for both lanes.
 - W4-CONFIG-01 has implementation, tests, and review.
 - W4-CONFIG-02 has implementation or an approved narrowed follow-up if status shape requires council review.
-- `bun run typecheck` and focused tests pass.
+- `bun run typecheck`, CI unit matrix, release gates, focused reload/push tests, and temp-binary acceptance pass.

--- a/.execution/program.md
+++ b/.execution/program.md
@@ -1,73 +1,60 @@
-# Program State
+# Jin Execution Program
 
-- phase: `release recovery`
-- current date: `2026-04-29`
-- current focus: `prune stale live-control artifacts, finish W3-CLEANUP-02, then harden release gates in W3-VALIDATE-02`
+Updated: 2026-05-13
+Branch: `fix/config-mutation-boundary-19`
+Focus: Config mutation boundary hardening after Desktop daemon IPC review.
 
-## TL;DR
+## Current Thesis
+
+Config-mutating CLI commands should not rely on indirect file watching as their primary apply path. They should write durable config, then ask the single running daemon to reload through the local API/socket boundary. File watching remains a compatibility and manual-edit fallback.
+
+## Active Packets
+
+| Packet | Status | Owner | Purpose |
+| --- | --- | --- | --- |
+| W4-CONFIG-01 | approved | worker | Daemon local API route for config reload and command-side notification |
+| W4-CONFIG-02 | queued | worker | Immutable reload/queue status snapshots for CLI and Desktop |
+
+## Dependency Graph
 
 ```mermaid
-flowchart LR
-  Cleanup02["W3-CLEANUP-02<br/>approved<br/>legacy CI cleanup landed"]
-  Validate02["W3-VALIDATE-02<br/>in_progress<br/>release-gate hardening"]
-  MainCI["main CI<br/>currently red"]
-  Release["v0.8.12 retag/release"]
+flowchart TD
+  BP07[BP-07 Process Lifecycle]
+  BP08[BP-08 Routing and Config]
+  ReloadPipeline[Current branch config-reload pipeline]
+  W4C01[W4-CONFIG-01 Daemon reload control]
+  W4C02[W4-CONFIG-02 Runtime reload and queue status]
+  Desktop[Desktop daemon IPC]
+  CLI[Config-mutating CLI commands]
 
-  Cleanup02 --> MainCI
-  Cleanup02 --> Validate02
-  Validate02 --> MainCI
-  MainCI --> Release
+  BP07 --> W4C01
+  BP08 --> W4C01
+  ReloadPipeline --> W4C01
+  W4C01 --> CLI
+  W4C01 --> W4C02
+  BP07 --> W4C02
+  BP08 --> W4C02
+  W4C02 --> Desktop
+  W4C02 --> CLI
 ```
 
-## Packet State
+## Coordination Rules
 
-- archived packet state: `.execution/archive/packets/`
-- live packets:
-  - `W3-CLEANUP-02` — `approved`
-  - `W3-VALIDATE-02` — `in_progress`
-  - `W3-SINK-04` — `needs_codex`
-  - `W3-E2E-01` — `review_ready`
-  - `W3-SERVICE-01` — `blocked`
-  - `W3-PR-01` — `blocked`
-- historical nonterminal packet files from the old Wave 3 rollout remain in
-  `.execution/packets/` for now and should be normalized or archived in a
-  second pass:
-  - `W3-ADAPTER-08`
-  - `W3-DOCS-01`
-  - `W3-PERF-04`
-  - `W3-PERF-07`
-  - `W3-PERF-09`
-  - `W3-PERF-10`
-  - `W3-PERF-11`
-  - `W3-SINK-05`
-  - `W3-UI-01`
+- W4-CONFIG-01 owns command apply and daemon reload route behavior.
+- W4-CONFIG-02 owns status DTOs and runtime queue/reload visibility.
+- Do not change Desktop renderer code in either packet.
+- Stop and update BP-07/BP-08 before implementing any contract extension that conflicts with frozen blueprint language.
 
-## Active Agents
+## Latest Status
 
-- `codex-BRAIN`
-- `codex-WORKER-release-gate-hardening`
+- W4-CONFIG-01 implementation is complete, focused validation is green, and BP/code rechecks passed.
+- Resolved review findings: sink enable/disable no longer mutates runtime pause state directly, config mutations cross the local daemon reload boundary, startup/reload strict validation rejects malformed generations, fatal reload shutdown skips stale final-flush, active sink-disable checks at push batch boundaries, and route/sink help includes `--yes` parity.
+- W4-CONFIG-02 should land after W4-CONFIG-01 so status can preserve the accepted-vs-completed distinction.
+- Huygens completed read-only design review for W4-CONFIG-02; recommended queue/reload snapshot fields were copied into the packet.
 
-Archived historical heartbeats live under:
+## Exit Criteria
 
-- `.execution/archive/agents/`
-
-## Next Dispatches
-
-- drive `W3-VALIDATE-02` to review-ready from the cleaned baseline
-- reconcile `W3-SINK-04` once release-path CI noise is gone
-- retag/release only after `main` CI is green again
-
-## Blockers
-
-- `main` CI is red on stale legacy release/unit surfaces
-- release `v0.8.12` must not be tagged until cleanup + validation hardening land
-- `.execution/blueprints.md` still reflects pre-merge `W3-SINK-06` / `W3-TEAM-03`
-  state and needs a separate reviewer-owned refresh
-
-## Notes
-
-- terminal packet-state files were archived to `.execution/archive/packets/`
-- stale tmp diagrams were moved to `docs/execution/archive/tmp-diagram/`
-- `docs/execution/tasks/` and `docs/execution/prompts/` were intentionally left
-  in place for now because they are still referenced by historical audits and
-  reviews; archive/migration of those docs should be a separate pass
+- Packets and prompts exist for both lanes.
+- W4-CONFIG-01 has implementation, tests, and review.
+- W4-CONFIG-02 has implementation or an approved narrowed follow-up if status shape requires council review.
+- `bun run typecheck` and focused tests pass.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@
 - Do not add standalone `.mmd` copies of Mermaid diagrams unless they are generated from a current source-of-truth doc or explicitly owned as first-class artifacts.
 - Prefer small, typed changes to existing files.
 - Run focused validation after changes when practical.
+- Prefer `bun run test` over raw `bun test` for broad local validation. The repo runner isolates each `.test.ts` file in a fresh Bun process so top-level `mock.module()` calls cannot leak across files.
+- Use `bun run test:integration` for the Docker-backed local Postgres persona test; it is intentionally outside the default unit suite.
 
 ## Workflow
 

--- a/docs/blueprint/BP-08-routing-and-config.md
+++ b/docs/blueprint/BP-08-routing-and-config.md
@@ -382,12 +382,12 @@ Most config-mutating commands follow this pattern:
 
 | Command | Mutates Config | Default Apply Path | Full Restart Optional? |
 |---------|---------------|--------------------|------------------------|
-| `jin sink add <type>` | Adds sink definition | Prioritized `config-reload` | Yes (`--yes`) |
-| `jin sink remove <id>` | Removes sink + routes | Prioritized `config-reload` | Yes (`--yes`) |
-| `jin sink disable/enable <id>` | Toggles sink delivery | Prioritized `config-reload` | Yes (`--yes`) |
-| `jin route add ...` | Adds route | Prioritized `config-reload` | Yes (`--yes`) |
-| `jin route remove ...` | Removes route | Prioritized `config-reload` | Yes (`--yes`) |
-| `jin adapter enable/disable` | Toggles adapter | Prioritized `config-reload` | Yes (`--yes`) |
+| `jin sink add <type>` | Adds sink definition | Prioritized `config-reload` | Yes (`--restart`) |
+| `jin sink remove <id>` | Removes sink + routes | Prioritized `config-reload` | Yes (`--restart`) |
+| `jin sink disable/enable <id>` | Toggles sink delivery | Prioritized `config-reload` | Yes (`--restart`) |
+| `jin route add ...` | Adds route | Prioritized `config-reload` | Yes (`--restart`) |
+| `jin route remove ...` | Removes route | Prioritized `config-reload` | Yes (`--restart`) |
+| `jin adapter enable/disable` | Toggles adapter | Prioritized `config-reload` | Yes (`--restart`) |
 
 ### Prioritized `config-reload`
 
@@ -419,7 +419,7 @@ This is the durable rule:
 ### Service Mode
 
 In service mode, live config reload remains the default path. If the operator
-explicitly requests `--yes`, the command delegates restart to the service
+explicitly requests `--restart`, the command delegates restart to the service
 manager:
 - macOS: `launchctl kickstart -k gui/${uid}/com.jin.agent`
 - Linux: `systemctl --user restart jin.service`
@@ -429,7 +429,7 @@ The config-mutating command does not fork a new daemon. It writes config and
 either:
 - causes the running owner to perform the same daemon-owned `config-reload`
   generation cutover, or
-- tells the service manager to restart if `--yes` was requested.
+- tells the service manager to restart if `--restart` was requested.
 
 ---
 
@@ -444,7 +444,7 @@ immediate runtime control without a restart:
 |------|-----------|-------|-------------|
 | **Emergency stop** | `jin stop` | Immediate local brake | Panic — "stop everything NOW" |
 | **Reconfigure** | Config mutation + prioritized `config-reload` | Immediate generation cutover | Planned change — add sink, update route, disable sink, retarget adapters |
-| **Full recycle** | Config mutation + restart (`--yes`) | ~2 seconds | Force a clean process restart after a config change |
+| **Full recycle** | Config mutation + restart (`--restart`) | ~2 seconds | Force a clean process restart after a config change |
 | **Selective replay** | `jin sink repush <id>` | Manual / bounded by push time | Repair — "re-deliver to this one sink" |
 
 ### Emergency Stop (`jin stop`)
@@ -488,7 +488,7 @@ jin sink enable <sink-id>
 - Ingest continues under the new generation — data accumulates in the store
 - Disable is **durable** — survives restart
 - `enable` sets `enabled: true` and uses the same reconfigure path
-- For permanent removal, use `jin sink remove <id> --yes`
+- For permanent removal, use `jin sink remove <id> --restart`
 
 **Why durable:** The "wrong sink / private data" scenario is exactly when
 the user might panic-restart (`jin stop` then `jin start`). If disable

--- a/docs/blueprint/BP-08-routing-and-config.md
+++ b/docs/blueprint/BP-08-routing-and-config.md
@@ -237,10 +237,15 @@ Why sink-scoped instead of top-level:
 - Later changes are applied through a prioritized `config-reload` control work
   item
 - The daemon may observe config changes from:
-  - config-mutating Jin commands that write durable config
+  - config-mutating Jin commands that write durable config and then request a
+    daemon-owned local control reload
   - a best-effort filesystem watcher on `config.json` for manual edits
 - first-party config-mutating commands must publish config atomically via
   durable replace semantics
+- first-party config-mutating commands must treat the daemon reload response as
+  an acceptance signal, not proof that the new generation has finished applying
+- if the daemon reload notification fails after a durable write, the command
+  must warn and leave the filesystem watcher / restart path as recovery
 - if a running daemon observes an invalid next config generation, it must stop
   and report the config error rather than continue serving the prior generation
 

--- a/docs/blueprint/BP-08-routing-and-config.md
+++ b/docs/blueprint/BP-08-routing-and-config.md
@@ -15,10 +15,10 @@ return which sinks should receive it. The pipeline (BP-02) calls this
 function at push time — it does not persist routing decisions. Config
 defines the rules; routing evaluates them.
 
-Config is durable intent. The running daemon is a snapshot of that intent.
-Changing config requires either restarting the daemon or using a
-config-mutating command that performs a controlled restart on the caller's
-behalf.
+Config is durable intent. The running daemon owns an in-memory applied view of
+that intent. Config changes do not take effect through ad hoc rereads in random
+call sites; they take effect only through a coordinator-owned `config-reload`
+transition or a full restart.
 
 ## Scope
 
@@ -26,7 +26,7 @@ BP-08 owns:
 - **Durable config schema** — adapters, sinks, routes, watch settings
 - **Route matching semantics** — glob patterns, AND logic, sink selection
 - **Config-mutating commands** — connect, disconnect, route add/remove
-- **Apply/restart semantics** — how config changes reach the runtime
+- **Apply/reload semantics** — how config changes reach the runtime
 - **Emergency runtime controls** — stop, sink disable/enable, sink repush
 
 BP-08 does NOT own:
@@ -232,16 +232,24 @@ Why sink-scoped instead of top-level:
 ### Loading
 
 - Config lives at `~/.config/jin/config.json` (or `$JIN_CONFIG_DIR/config.json`)
-- Loaded **once** at startup, snapshotted for the session (BP-07 invariant)
-- Changes to the config file require restart to take effect
-- No hot-reload in v2
+- The runtime loads an initial config at startup and treats it as generation 0
+  of the active runtime config
+- Later changes are applied through a prioritized `config-reload` control work
+  item
+- The daemon may observe config changes from:
+  - config-mutating Jin commands that write durable config
+  - a best-effort filesystem watcher on `config.json` for manual edits
+- first-party config-mutating commands must publish config atomically via
+  durable replace semantics
+- if a running daemon observes an invalid next config generation, it must stop
+  and report the config error rather than continue serving the prior generation
 
-**Why no hot-reload:** Config changes can add/remove sinks, change routes,
-or disable adapters. These affect the coordinator's adapter set, watcher
-paths, and sink connections. Applying mid-run safely would require a
-config-change work item in the coordinator queue with full adapter/sink
-reconciliation. The restart cost is ~2 seconds (re-ingest is fast because
-bundle hashes skip unchanged data via BP-05).
+**Why explicit reload instead of ad hoc hot-reload:** Config changes can
+add/remove sinks, change routes, or disable adapters. These affect the
+coordinator's adapter set, watcher paths, sink connections, and push
+selection. Jin must therefore funnel config transitions through one explicit
+coordinator-owned reload path rather than letting arbitrary subsystems reread
+the file whenever they notice disk activity.
 
 ### First Run
 
@@ -286,7 +294,8 @@ Steps:
 2. Add sink to `config.sinks[]`
 3. **Prompt: "Add a route to this sink?"** — offers to create a route
    immediately so the sink starts receiving data
-4. Write config; prompt to restart if daemon is running
+4. Write config atomically
+5. If the daemon is running, trigger a prioritized config reload
 
 A sink with no routes targeting it receives nothing. `jin status` warns:
 ```
@@ -347,58 +356,75 @@ For v2, use `jin sink add` / `jin sink remove` and `jin route add` /
 
 ---
 
-## Config Mutation and Controlled Restart
+## Config Mutation and Live Apply
 
-Config-mutating commands write durable config. They do not hot-patch the
-live runtime. Instead, they can optionally trigger a controlled restart.
+Config-mutating commands write durable config. By default, a running daemon
+should absorb those changes through the prioritized `config-reload` path
+without a full process restart.
 
 ### The Pattern
 
 ```
-jin sink add postgres --connection-string="..." --user-id="eden" --yes
+jin sink add postgres --connection-string="..." --user-id="eden"
   1. Validates connection (healthCheck)
-  2. Writes sink to config.json
-  3. --yes: stops running daemon → starts it again (config reloaded)
-     (no --yes: prints "Restart jin to apply changes")
+  2. Writes config atomically
+  3. If the daemon is running, trigger prioritized `config-reload`
+  4. The coordinator reloads config, reconciles adapters/watchers/sinks,
+     and future push work uses the new routes
 ```
 
 Most config-mutating commands follow this pattern:
 
-| Command | Mutates Config | Restartable |
-|---------|---------------|-------------|
-| `jin sink add <type>` | Adds sink definition | Yes (`--yes`) |
-| `jin sink remove <id>` | Removes sink + routes | Yes (`--yes`) |
-| `jin route add ...` | Adds route | Yes (`--yes`) |
-| `jin route remove ...` | Removes route | Yes (`--yes`) |
-| `jin adapter enable/disable` | Toggles adapter | Yes (`--yes`) |
+| Command | Mutates Config | Default Apply Path | Full Restart Optional? |
+|---------|---------------|--------------------|------------------------|
+| `jin sink add <type>` | Adds sink definition | Prioritized `config-reload` | Yes (`--yes`) |
+| `jin sink remove <id>` | Removes sink + routes | Prioritized `config-reload` | Yes (`--yes`) |
+| `jin sink disable/enable <id>` | Toggles sink delivery | Prioritized `config-reload` | Yes (`--yes`) |
+| `jin route add ...` | Adds route | Prioritized `config-reload` | Yes (`--yes`) |
+| `jin route remove ...` | Removes route | Prioritized `config-reload` | Yes (`--yes`) |
+| `jin adapter enable/disable` | Toggles adapter | Prioritized `config-reload` | Yes (`--yes`) |
 
-**Exception — `jin sink disable/enable`:** See §Selective Sink Disable
-below. Disable writes durable config AND signals the runtime immediately
-without a full restart. This is an explicit exception to the "config
-changes require restart" rule because disable is an operator safety
-control that must take effect within seconds, not after a restart cycle.
+### Prioritized `config-reload`
 
-### Why Not Hot-Reload
+`config-reload` is a control-plane event, not just another background task.
 
-Hot-reload requires:
-- Adapter set reconciliation (watchers, caches)
-- Sink connection lifecycle (open new, close removed)
-- Route evaluation against new rules mid-push
-- Coordinator awareness of config transitions
+Requirements:
 
-Controlled restart gets all of this for free — the startup sequence
-(BP-07) handles it. The cost is ~2 seconds of downtime during which no
-pushes occur. Data is safe in SQLite.
+- it must jump ahead of ordinary queued `push` and periodic ingest work
+- it must coalesce repeated config-disk churn into the latest durable config
+- it must validate the next generation before resuming normal work
+- if the next generation is invalid, the runtime must stop and surface the
+  config error; it must not continue on the previous generation
+- it must reload the whole config generation, not patch individual fields in
+  place from scattered call sites
+- it must rebuild the active sink set
+- it must refresh route selection inputs
+- it must refresh adapter config used for discovery/load and watcher
+  reconciliation
+- it must reconcile watched paths and runtime timers against the new adapter
+  set
+
+This is the durable rule:
+
+> Config changes become live only when the coordinator commits a
+> `config-reload` transition or the process restarts. If the next config
+> generation is invalid, the runtime stops instead of continuing on stale
+> config.
 
 ### Service Mode
 
-In service mode, `--yes` delegates restart to the service manager:
+In service mode, live config reload remains the default path. If the operator
+explicitly requests `--yes`, the command delegates restart to the service
+manager:
 - macOS: `launchctl kickstart -k gui/${uid}/com.jin.agent`
 - Linux: `systemctl --user restart jin.service`
 - Windows: restart via Task Scheduler
 
-The config-mutating command does not fork a new daemon. It writes config
-and tells the service manager to restart.
+The config-mutating command does not fork a new daemon. It writes config and
+either:
+- causes the running owner to perform the same daemon-owned `config-reload`
+  generation cutover, or
+- tells the service manager to restart if `--yes` was requested.
 
 ---
 
@@ -407,13 +433,13 @@ and tells the service manager to restart.
 Config mutation covers planned changes. But there are scenarios that need
 immediate runtime control without a restart:
 
-### Three Distinct Control Needs
+### Four Distinct Control Needs
 
 | Need | Mechanism | Speed | When to use |
 |------|-----------|-------|-------------|
-| **Emergency stop** | `jin stop` | Immediate (seconds) | Panic — "stop everything NOW" |
-| **Reconfigure** | Config mutation + restart | ~2 seconds | Planned change — add sink, update route |
-| **Selective disable** | `jin sink disable <id>` | Immediate | Calm — "stop pushing to this one sink" |
+| **Emergency stop** | `jin stop` | Immediate local brake | Panic — "stop everything NOW" |
+| **Reconfigure** | Config mutation + prioritized `config-reload` | Immediate generation cutover | Planned change — add sink, update route, disable sink, retarget adapters |
+| **Full recycle** | Config mutation + restart (`--yes`) | ~2 seconds | Force a clean process restart after a config change |
 | **Selective replay** | `jin sink repush <id>` | Manual / bounded by push time | Repair — "re-deliver to this one sink" |
 
 ### Emergency Stop (`jin stop`)
@@ -423,16 +449,16 @@ not remember sink IDs or think about routes. They will type `jin stop`.
 
 **This is correct behavior.** `jin stop` is the emergency brake:
 
-1. Triggers graceful shutdown (BP-07)
-2. In-flight push completes current batch (max 20 conversations)
-3. All pushes stop
+1. Triggers shutdown (BP-07)
+2. Stops admitting new ingest/push work immediately
+3. Aborts any Jin-local adapter/push worker execution still in flight
 4. Data is safe in local SQLite
 5. User investigates, fixes routes, restarts
 
-**Blast radius:** Bounded by one push batch (20 conversations × N sinks).
-If the user types `jin stop` within seconds of noticing the problem, at
-most one or two batches have been sent. Already-sent data cannot be
-revoked — if an HTTP request or SQL batch landed, it landed.
+**Blast radius:** Bounded by data that has already left Jin. Already-sent data
+cannot be revoked — if an HTTP request, object upload, or SQL transaction
+landed before the local brake, it landed. But Jin must not keep pushing the old
+generation just because a large payload or batch was already underway.
 
 **Recovery:** Fix config (`jin route remove`, `jin sink remove`), then
 `jin start`. The store retains all data. Push resumes only to sinks
@@ -449,12 +475,14 @@ jin sink enable <sink-id>
 ```
 
 **Semantics:**
-- `disable` sets `enabled: false` on the sink in durable config AND
-  signals the runtime so the coordinator skips this sink immediately
-- Other sinks continue pushing normally
-- Ingest continues — data accumulates in the store
+- `disable` sets `enabled: false` on the sink in durable config and triggers
+  the same prioritized `config-reload` path as any other config mutation
+- Active push work that is still local to Jin should be interrupted immediately;
+  already-landed remote writes cannot be revoked
+- Other sinks continue pushing once the new generation commits
+- Ingest continues under the new generation — data accumulates in the store
 - Disable is **durable** — survives restart
-- `enable` sets `enabled: true` and signals the runtime
+- `enable` sets `enabled: true` and uses the same reconfigure path
 - For permanent removal, use `jin sink remove <id> --yes`
 
 **Why durable:** The "wrong sink / private data" scenario is exactly when
@@ -463,13 +491,10 @@ were ephemeral, the restart re-enables the sink and resumes pushing to the
 wrong place. Durable disable means the sink stays off until the user
 explicitly enables it.
 
-**Why disable is an exception to the no-hot-patch rule:** Most config
-changes (add sink, add route) require restart because they affect the
-coordinator's adapter set, watcher paths, and sink connections. Disable is
-different — it only sets a filter flag that `pushDirty()` checks before
-including a sink. No reconnection, no watcher change, no adapter
-reconciliation. The runtime can absorb this change safely without a full
-restart cycle.
+**Why disable is no longer mechanically special:** v2 live apply treats all
+delivery-affecting config changes as real-time brakes. `jin sink disable` is
+still an important operator surface, but it should not require a sink-specific
+runtime control lane separate from the main config generation cutover.
 
 `jin status` shows disabled sinks clearly:
 ```
@@ -479,10 +504,10 @@ Sinks:
                       Run: jin sink enable s3-archive
 ```
 
-**Implementation:** `pushDirty()` checks `sink.enabled` before including
-a sink. No new work queue item type — it's a filter, not a work item.
-`disable` writes config and signals the runtime via the daemon boundary
-so the change takes effect immediately without a full restart.
+**Implementation:** the coordinator rebuilds active sinks from durable config on
+the next generation cutover. If an in-flight push worker is interrupted before
+returning success, the parent records no new success for those payloads and
+they remain dirty for a later retry.
 
 ### Selective Sink Repush
 
@@ -550,7 +575,7 @@ durable state.
 | Glob patterns (not regex) | Switching to regex changes every route in every config file. Globs cover 99% of use cases and are simpler. |
 | `git_remote` as primary routing key | Config, deployment guides, and route examples all use git_remote. Reverting to cwd breaks cross-machine routing. |
 | No default/fallback sinks | Every push requires an explicit route match. Adding a catch-all later is easy (wildcard route). Removing an accidental catch-all after data has been pushed is not. Safe zero-state is a one-way door. |
-| Config snapshot at startup | Adding hot-reload requires coordinator work items for config transitions. Snapshot is simpler and avoids mid-push route changes. |
+| Coordinator-owned config reload | Live apply is valuable, but only if the daemon owns the transition. Arbitrary call-site rereads would make push selection, sink lifecycle, and watcher reconciliation nondeterministic. |
 | SinkConfig discriminated union | Code that switches on `type` depends on the union structure. Flattening back to a bag breaks type narrowing everywhere. |
 
 ---

--- a/docs/blueprint/mermaid/bp-08-config-mutation-and-runtime-control.mmd
+++ b/docs/blueprint/mermaid/bp-08-config-mutation-and-runtime-control.mmd
@@ -8,7 +8,7 @@ flowchart TD
     Runtime -->|Yes| Control["daemon local control API<br/>POST /api/control/config/reload"]
     Control --> Ack["202 accepted means queued/coalesced<br/>not completed"]
     Ack --> Reload["prioritized config-reload<br/>rebuild sinks/routes/adapters"]
-    Runtime -->|--yes when supported| Restart["controlled restart<br/>stop runtime -> reload config -> start runtime"]
+    Runtime -->|--restart when supported| Restart["controlled restart<br/>stop runtime -> reload config -> start runtime"]
 
     Disable["jin sink disable <id>"] --> Durable["set sink.enabled = false in durable config"]
     Durable --> Control

--- a/docs/blueprint/mermaid/bp-08-config-mutation-and-runtime-control.mmd
+++ b/docs/blueprint/mermaid/bp-08-config-mutation-and-runtime-control.mmd
@@ -3,12 +3,13 @@
 
 flowchart TD
     Mutate["jin sink add/remove<br/>jin route add/remove<br/>jin adapter enable/disable"] --> Validate["validate + write config.json"]
-    Validate --> RestartChoice{"apply immediately?"}
-    RestartChoice -->|No| Prompt["print restart instruction"]
-    RestartChoice -->|Yes or --yes| Restart["controlled restart<br/>stop runtime -> reload config -> start runtime"]
+    Validate --> Runtime{"runtime running?"}
+    Runtime -->|No| NextStart["applies on next start"]
+    Runtime -->|Yes| Reload["prioritized config-reload<br/>rebuild sinks/routes/adapters"]
+    Runtime -->|--yes| Restart["controlled restart<br/>stop runtime -> reload config -> start runtime"]
 
     Disable["jin sink disable <id>"] --> Durable["set sink.enabled = false in durable config"]
-    Durable --> Signal["signal runtime immediately"]
-    Signal --> Skip["pushDirty() skips that sink<br/>no full restart required"]
+    Durable --> Reload
+    Reload --> Apply["future push work uses<br/>committed config generation"]
 
-    Stop["jin stop"] --> Shutdown["emergency stop<br/>preempt queue, close watchers/timers,<br/>final bounded flush, exit"]
+    Stop["jin stop"] --> Shutdown["emergency stop<br/>preempt queue, close watchers/timers,<br/>cancel local work, exit"]

--- a/docs/blueprint/mermaid/bp-08-config-mutation-and-runtime-control.mmd
+++ b/docs/blueprint/mermaid/bp-08-config-mutation-and-runtime-control.mmd
@@ -2,14 +2,18 @@
 %% Diagram: Config Mutation and Runtime Control
 
 flowchart TD
-    Mutate["jin sink add/remove<br/>jin route add/remove<br/>jin adapter enable/disable"] --> Validate["validate + write config.json"]
+    Mutate["jin sink add/remove/enable/disable<br/>jin route add/remove<br/>jin adapter enable/disable"] --> Validate["validate + atomically write config.json"]
     Validate --> Runtime{"runtime running?"}
     Runtime -->|No| NextStart["applies on next start"]
-    Runtime -->|Yes| Reload["prioritized config-reload<br/>rebuild sinks/routes/adapters"]
-    Runtime -->|--yes| Restart["controlled restart<br/>stop runtime -> reload config -> start runtime"]
+    Runtime -->|Yes| Control["daemon local control API<br/>POST /api/control/config/reload"]
+    Control --> Ack["202 accepted means queued/coalesced<br/>not completed"]
+    Ack --> Reload["prioritized config-reload<br/>rebuild sinks/routes/adapters"]
+    Runtime -->|--yes when supported| Restart["controlled restart<br/>stop runtime -> reload config -> start runtime"]
 
     Disable["jin sink disable <id>"] --> Durable["set sink.enabled = false in durable config"]
-    Durable --> Reload
+    Durable --> Control
     Reload --> Apply["future push work uses<br/>committed config generation"]
+    Validate --> Watcher["best-effort fs.watch fallback<br/>manual edits / notification failure"]
+    Watcher --> Reload
 
     Stop["jin stop"] --> Shutdown["emergency stop<br/>preempt queue, close watchers/timers,<br/>cancel local work, exit"]

--- a/docs/execution/prompts/W4-CONFIG-01-review-codex.md
+++ b/docs/execution/prompts/W4-CONFIG-01-review-codex.md
@@ -21,8 +21,13 @@ Use a code-review mindset. Findings first, ordered by severity, with file and li
 - Does the daemon delegate to the coordinator reload work item?
 - Does file watching remain a fallback rather than the only apply mechanism?
 - Are daemon-unavailable and notification-failure cases clear to users?
+- Does a successful config reload enqueue push so new or retargeted sinks process existing backlog without waiting for another ingest?
+- Does active push work re-check current sink existence, sink enablement, and routes before each local batch?
+- If config changes during an in-flight sink push, does local delivery state remain dirty rather than recording stale success?
+- Do external sink health checks run outside the config write lock?
+- Is explicit full-restart behavior consistently exposed as `--restart` for config mutations?
 - Are secrets excluded from any new response or logs?
-- Are tests sufficient for command path, local API auth, and fallback behavior?
+- Are tests sufficient for command path, local API auth, fallback behavior, retargeted-sink backlog, active push brakes, in-flight config change, and sink health preflight?
 - Does the implementation violate BP-07, BP-08, or ontology language?
 
 ## Output

--- a/docs/execution/prompts/W4-CONFIG-01-review-codex.md
+++ b/docs/execution/prompts/W4-CONFIG-01-review-codex.md
@@ -1,0 +1,30 @@
+# Review Prompt - W4-CONFIG-01
+
+Review the implementation of `docs/execution/tasks/W4-CONFIG-01-daemon-reload-control.md`.
+
+Use a code-review mindset. Findings first, ordered by severity, with file and line references.
+
+## Required Read Order
+
+1. `docs/execution/00-global-rules.md`
+2. `docs/execution/01-dispatch-protocol.md`
+3. `docs/execution/tasks/W4-CONFIG-01-daemon-reload-control.md`
+4. `docs/ontology.md`
+5. `docs/blueprint/BP-07-process-lifecycle.md`
+6. `docs/blueprint/BP-08-routing-and-config.md`
+7. Changed files in the implementation
+
+## Review Questions
+
+- Does the command path persist config before daemon notification?
+- Does reload go through the daemon local API and existing auth?
+- Does the daemon delegate to the coordinator reload work item?
+- Does file watching remain a fallback rather than the only apply mechanism?
+- Are daemon-unavailable and notification-failure cases clear to users?
+- Are secrets excluded from any new response or logs?
+- Are tests sufficient for command path, local API auth, and fallback behavior?
+- Does the implementation violate BP-07, BP-08, or ontology language?
+
+## Output
+
+Return findings first. Then include open questions, tests reviewed, BP acceptance matrix result, and V1 comparison.

--- a/docs/execution/prompts/W4-CONFIG-01-worker-codex.md
+++ b/docs/execution/prompts/W4-CONFIG-01-worker-codex.md
@@ -1,0 +1,41 @@
+# Worker Prompt - W4-CONFIG-01
+
+You are implementing `docs/execution/tasks/W4-CONFIG-01-daemon-reload-control.md` on branch `fix/config-mutation-boundary-19`.
+
+You are not alone in the codebase. Do not revert changes made by others. Keep your writes inside the packet-owned files unless you stop and explain why the packet boundary is insufficient.
+
+## Mission
+
+Move first-party config mutation apply from indirect file-watch-only behavior to an explicit daemon local API reload request.
+
+## Required Read Order
+
+1. `docs/execution/00-global-rules.md`
+2. `docs/execution/01-dispatch-protocol.md`
+3. `docs/execution/tasks/W4-CONFIG-01-daemon-reload-control.md`
+4. `docs/ontology.md`
+5. `docs/blueprint/BP-07-process-lifecycle.md`
+6. `docs/blueprint/BP-08-routing-and-config.md`
+7. `src/commands/config-control.ts`
+8. `src/commands/watch.ts`
+9. `src/api/control.ts`
+10. `src/api/routes.ts`
+11. `src/api/server.ts`
+
+## Implementation Constraints
+
+- Durable config write happens before daemon notification.
+- The daemon route must use existing local auth.
+- The daemon route delegates to the coordinator reload path, not a command-side runtime.
+- Keep file-watch reload as fallback.
+- Add tests before or with the implementation.
+- Do not touch Desktop UI code, adapters, sinks, or store schema.
+
+## Required Validation
+
+- `bun run typecheck`
+- `bun test test/config-mutation-control.test.ts test/local-control-boundary.test.ts`
+
+## Final Response
+
+Include changed files, tests run, BP acceptance result, V1 comparison, and any follow-up needed for W4-CONFIG-02.

--- a/docs/execution/prompts/W4-CONFIG-01-worker-codex.md
+++ b/docs/execution/prompts/W4-CONFIG-01-worker-codex.md
@@ -6,7 +6,7 @@ You are not alone in the codebase. Do not revert changes made by others. Keep yo
 
 ## Mission
 
-Move first-party config mutation apply from indirect file-watch-only behavior to an explicit daemon local API reload request.
+Move first-party config mutation apply from indirect file-watch-only behavior to an explicit daemon local API reload request, then harden sink push behavior when routes/sinks change while push work is active.
 
 ## Required Read Order
 
@@ -28,6 +28,11 @@ Move first-party config mutation apply from indirect file-watch-only behavior to
 - The daemon route must use existing local auth.
 - The daemon route delegates to the coordinator reload path, not a command-side runtime.
 - Keep file-watch reload as fallback.
+- Successful config reload enqueues push so added or retargeted sinks receive existing backlog immediately.
+- Push batches re-check current sink existence, sink enablement, and current routes before egress.
+- If config changes while a sink batch is in flight, do not record local delivery success for that batch.
+- External sink health checks must run outside the config write lock.
+- Config-mutation full restart is requested with `--restart`.
 - Add tests before or with the implementation.
 - Do not touch Desktop UI code, adapters, sinks, or store schema.
 
@@ -35,6 +40,7 @@ Move first-party config mutation apply from indirect file-watch-only behavior to
 
 - `bun run typecheck`
 - `bun test test/config-mutation-control.test.ts test/local-control-boundary.test.ts`
+- `bun test test/pipeline-spine.test.ts`
 
 ## Final Response
 

--- a/docs/execution/prompts/W4-CONFIG-02-review-codex.md
+++ b/docs/execution/prompts/W4-CONFIG-02-review-codex.md
@@ -1,0 +1,29 @@
+# Review Prompt - W4-CONFIG-02
+
+Review the implementation of `docs/execution/tasks/W4-CONFIG-02-runtime-reload-status.md`.
+
+Use a code-review mindset. Findings first, ordered by severity, with file and line references.
+
+## Required Read Order
+
+1. `docs/execution/00-global-rules.md`
+2. `docs/execution/01-dispatch-protocol.md`
+3. `docs/execution/tasks/W4-CONFIG-02-runtime-reload-status.md`
+4. `docs/ontology.md`
+5. `docs/blueprint/BP-07-process-lifecycle.md`
+6. `docs/blueprint/BP-08-routing-and-config.md`
+7. Changed files in the implementation
+
+## Review Questions
+
+- Is the runtime snapshot immutable and safe to serialize?
+- Does status expose reload pending/current/last outcome clearly enough for CLI and Desktop?
+- Are queue fields useful without leaking implementation internals?
+- Are config and sink secrets excluded?
+- Does the shape avoid Desktop-only contracts for CLI-relevant state?
+- Are tests sufficient for immutability, reload transitions, and secret safety?
+- Does the implementation violate BP-07, BP-08, or ontology language?
+
+## Output
+
+Return findings first. Then include open questions, tests reviewed, BP acceptance matrix result, and V1 comparison.

--- a/docs/execution/prompts/W4-CONFIG-02-worker-codex.md
+++ b/docs/execution/prompts/W4-CONFIG-02-worker-codex.md
@@ -1,0 +1,42 @@
+# Worker Prompt - W4-CONFIG-02
+
+You are implementing `docs/execution/tasks/W4-CONFIG-02-runtime-reload-status.md` on branch `fix/config-mutation-boundary-19`.
+
+You are not alone in the codebase. Do not revert changes made by others. Keep your writes inside the packet-owned files unless you stop and explain why the packet boundary is insufficient.
+
+## Mission
+
+Expose immutable, secret-safe runtime queue and config reload status through Jin's daemon-owned status boundary.
+
+## Required Read Order
+
+1. `docs/execution/00-global-rules.md`
+2. `docs/execution/01-dispatch-protocol.md`
+3. `docs/execution/tasks/W4-CONFIG-02-runtime-reload-status.md`
+4. `docs/ontology.md`
+5. `docs/blueprint/BP-07-process-lifecycle.md`
+6. `docs/blueprint/BP-08-routing-and-config.md`
+7. `src/pipeline/types.ts`
+8. `src/pipeline/queue.ts`
+9. `src/pipeline/loop.ts`
+10. `src/commands/watch.ts`
+11. `src/commands/status.ts`
+12. `src/api/control.ts`
+13. `src/api/routes.ts`
+
+## Implementation Constraints
+
+- Do not expose mutable queue objects.
+- Do not leak config secrets, sink URLs, tokens, or credentials.
+- Keep DTOs typed and small.
+- Do not change config mutation command behavior; W4-CONFIG-01 owns that.
+- Do not touch Desktop renderer code.
+
+## Required Validation
+
+- `bun run typecheck`
+- `bun test test/pipeline-spine.test.ts test/local-control-boundary.test.ts`
+
+## Final Response
+
+Include changed files, tests run, BP acceptance result, V1 comparison, and any fields deferred.

--- a/docs/execution/tasks/W4-CONFIG-01-daemon-reload-control.md
+++ b/docs/execution/tasks/W4-CONFIG-01-daemon-reload-control.md
@@ -1,0 +1,138 @@
+# W4-CONFIG-01 - Daemon Config Reload Control Boundary
+
+Status: review_ready
+Owner: worker
+Branch: fix/config-mutation-boundary-19
+
+## Role
+
+Implement the first-party config mutation apply path through the daemon's local control boundary.
+
+## Goal
+
+When a Jin command mutates `config.json`, the command must persist the config durably, then ask the already-running daemon to reload through the daemon-owned local API/socket control plane. File watching remains a fallback for manual edits and third-party writers, not the primary command-to-runtime synchronization path.
+
+## Depends On
+
+- `docs/ontology.md`
+- `docs/blueprint/BP-07-process-lifecycle.md`
+- `docs/blueprint/BP-08-routing-and-config.md`
+- Current branch reload pipeline work in `src/commands/watch.ts` and `src/pipeline/**`
+- Desktop daemon-query direction from PR 55: one daemon-owned local boundary, Desktop and CLI as clients
+
+## Unblocks
+
+- Immediate config apply semantics for `jin connect`, `jin sink`, and `jin route`
+- Desktop-safe runtime control without starting a second runtime
+- W4-CONFIG-02 status/queue observability
+
+## Read In Order
+
+1. `docs/execution/00-global-rules.md`
+2. `docs/execution/01-dispatch-protocol.md`
+3. `docs/execution/05-live-control-plane.md`
+4. `docs/ontology.md`
+5. `docs/blueprint/BP-07-process-lifecycle.md`
+6. `docs/blueprint/BP-08-routing-and-config.md`
+7. `src/commands/config-control.ts`
+8. `src/commands/watch.ts`
+9. `src/api/control.ts`
+10. `src/api/routes.ts`
+11. `src/api/server.ts`
+12. `test/config-mutation-control.test.ts`
+13. `test/local-control-boundary.test.ts`
+
+## Owned Files
+
+- `src/api/control.ts`
+- `src/api/routes.ts`
+- `src/api/server.ts`
+- `src/api/client.ts` if a shared local API client is introduced
+- `src/commands/config-control.ts`
+- `src/commands/sink.ts`
+- `src/commands/watch.ts`
+- `src/config.ts`
+- `src/index.ts`
+- `src/pipeline/types.ts`
+- `src/pipeline/loop.ts`
+- `src/pipeline/push.ts`
+- `test/config.test.ts`
+- `test/config-mutation-control.test.ts`
+- `test/local-control-boundary.test.ts`
+- `test/pipeline-spine.test.ts`
+- A new focused test file under `test/` if needed
+- `docs/blueprint/BP-08-routing-and-config.md`
+- `docs/blueprint/mermaid/bp-08-config-mutation-and-runtime-control.mmd`
+
+## Forbidden Boundaries
+
+- Do not change Desktop renderer or UI code.
+- Do not change adapter ingestion semantics.
+- Do not change sink write schemas or routing rules.
+- Do not modify unrelated ingestion, adapter, or sink payload semantics.
+- Do not add a second runtime, hidden worker, or process-local shortcut that bypasses the daemon boundary.
+- Do not make file watching the only supported command apply path.
+
+## Required Design
+
+- Add a daemon-local control route for config reload, for example `POST /api/control/config/reload`.
+- The route must require the same local daemon authentication as existing control/status routes.
+- The route must enqueue the existing coordinator-owned config reload path and return an acknowledgement.
+- First-party config-mutating commands should call this route after durable config write when a daemon is running.
+- If the daemon is not running, the command should keep current "applies on next start" behavior.
+- If the daemon notification fails but the daemon is expected to be running, the command must surface a clear warning and rely on the file watcher fallback rather than silently claiming success.
+- `fs.watch(config.json)` remains as a fallback for manual edits, MDM/profile writes, old clients, and recovery.
+
+## Acceptance Checks
+
+- `bun run typecheck`
+- `bun test test/config-mutation-control.test.ts test/local-control-boundary.test.ts`
+- A focused test proving the command path calls the daemon reload route or injected equivalent after a config mutation.
+- A focused test proving unauthenticated reload requests are rejected at the local API boundary.
+- A focused test proving daemon-unavailable behavior does not corrupt config and reports next-start or fallback semantics.
+
+## BP Acceptance Matrix
+
+| BP | Requirement | Evidence |
+| --- | --- | --- |
+| BP-07 | Desktop and CLI use the daemon as the single local runtime authority. | Reload is exposed through daemon local API/socket, not through repo-local Bun or an in-command runtime. |
+| BP-07 | Local control surfaces are authenticated and transport-owned. | Reload route uses existing local auth and transport behavior. |
+| BP-08 | Config mutation commands persist durable config first. | Commands still use `updateConfig` / `saveConfig` before daemon notification. |
+| BP-08 | Runtime config changes are applied by the coordinator pipeline. | Reload route delegates to `PipelineHandle.reloadConfig` / coordinator work item. |
+| BP-08 | Manual config edits remain supported. | File watcher fallback remains and is covered by tests or explicit non-regression. |
+
+## V1 Comparison
+
+V1-era behavior relied on restart expectations and ad hoc command-side assumptions. This packet intentionally replaces that with a daemon-owned reload request. The compatibility contract is user-facing behavior, not internal implementation: config commands must remain safe, durable, and understandable. Existing v1-only shortcuts or dead restart assumptions should not be preserved.
+
+## Stop And Escalate
+
+Stop before implementation if the daemon local API cannot safely distinguish an accepted reload request from a completed reload. That may require W4-CONFIG-02 status work to land first or a narrowed response contract.
+
+## Completion Report
+
+Report changed files, acceptance checks, BP matrix result, V1 comparison, and any follow-up required for W4-CONFIG-02.
+
+## Current Result
+
+- Implemented authenticated `POST /api/control/config/reload`.
+- Wired daemon startup to delegate reload requests to `PipelineHandle.reloadConfig("command")`.
+- Config-mutating commands now notify the daemon after durable writes and warn on notification failure.
+- `jin sink enable/disable` now participates in the reload notification path without mutating runtime pause state directly.
+- `jin sink enable/disable --yes` now has controlled-restart parity with other config-mutating sink commands.
+- Existing config mutations and live reload now reject invalid sink/route/watch generations instead of silently normalizing malformed entries away.
+- Startup now rejects invalid existing config instead of normalizing it into the live generation.
+- Invalid live reload now stops without running shutdown final-flush against stale sinks/routes.
+- Active push work now checks durable sink enablement before each local batch, so disabling a sink stops remaining local batches after any already-in-flight batch.
+- BP-08 and the config mutation Mermaid source clarify accepted-vs-completed reload semantics.
+- Pasteur review findings were addressed: direct sink pause mutation removed, `--yes` parity added, and strict runtime config generation validation added.
+- Rawls/Euler review findings were addressed: startup strict validation, no-flush fatal reload shutdown, active push batch gating, and route help `--yes` visibility.
+
+## Validation
+
+- `bun run typecheck`
+- `bun test test/config-mutation-control.test.ts test/local-control-boundary.test.ts test/daemon-query-boundary.test.ts test/desktop-shell-service.test.ts`
+- `bun test test/config.test.ts test/config-mutation-control.test.ts`
+- `bun test test/pipeline-spine.test.ts test/runtime-store-cutover.test.ts`
+- `bun run test:release-gates`
+- Disposable real-daemon smoke: `bun /private/tmp/jin-midrun-reload-smoke.ts ./jin .`

--- a/docs/execution/tasks/W4-CONFIG-01-daemon-reload-control.md
+++ b/docs/execution/tasks/W4-CONFIG-01-daemon-reload-control.md
@@ -78,10 +78,18 @@ When a Jin command mutates `config.json`, the command must persist the config du
 - Add a daemon-local control route for config reload, for example `POST /api/control/config/reload`.
 - The route must require the same local daemon authentication as existing control/status routes.
 - The route must enqueue the existing coordinator-owned config reload path and return an acknowledgement.
+- A successful config reload must enqueue push work so newly added or retargeted sinks recompute backlog immediately under the new route generation.
 - First-party config-mutating commands should call this route after durable config write when a daemon is running.
 - If the daemon is not running, the command should keep current "applies on next start" behavior.
 - If the daemon notification fails but the daemon is expected to be running, the command must surface a clear warning and rely on the file watcher fallback rather than silently claiming success.
 - `fs.watch(config.json)` remains as a fallback for manual edits, MDM/profile writes, old clients, and recovery.
+- Push work must re-check current config at local batch boundaries before data leaves Jin:
+  - sink still exists
+  - sink is still enabled
+  - candidate conversations still route to that sink under current routes
+- If config changes while a sink batch is in flight, the pipeline must not record local success for that batch; remote writes may have landed, but local delivery state stays conservative for idempotent retry.
+- External sink health checks must not run while holding the config write lock.
+- The full-restart override flag is `--restart`.
 
 ## Acceptance Checks
 
@@ -90,6 +98,10 @@ When a Jin command mutates `config.json`, the command must persist the config du
 - A focused test proving the command path calls the daemon reload route or injected equivalent after a config mutation.
 - A focused test proving unauthenticated reload requests are rejected at the local API boundary.
 - A focused test proving daemon-unavailable behavior does not corrupt config and reports next-start or fallback semantics.
+- A focused test proving config reload enqueues push so an added/retargeted sink receives existing dirty backlog without waiting for another ingest.
+- Focused tests proving route removal, sink removal, and sink disable stop remaining local push batches.
+- A focused test proving config changes during an in-flight sink push leave local push state dirty.
+- A focused test proving sink health checks run outside the config lock.
 
 ## BP Acceptance Matrix
 
@@ -99,6 +111,8 @@ When a Jin command mutates `config.json`, the command must persist the config du
 | BP-07 | Local control surfaces are authenticated and transport-owned. | Reload route uses existing local auth and transport behavior. |
 | BP-08 | Config mutation commands persist durable config first. | Commands still use `updateConfig` / `saveConfig` before daemon notification. |
 | BP-08 | Runtime config changes are applied by the coordinator pipeline. | Reload route delegates to `PipelineHandle.reloadConfig` / coordinator work item. |
+| BP-08 | Delivery-affecting config changes are real-time brakes. | Push batches re-read current config before egress and avoid recording success across generation changes. |
+| BP-08 | New or retargeted sinks receive backlog from existing local revisions. | Successful reload enqueues push; push state remains per-sink revision based. |
 | BP-08 | Manual config edits remain supported. | File watcher fallback remains and is covered by tests or explicit non-regression. |
 
 ## V1 Comparison
@@ -119,14 +133,17 @@ Report changed files, acceptance checks, BP matrix result, V1 comparison, and an
 - Wired daemon startup to delegate reload requests to `PipelineHandle.reloadConfig("command")`.
 - Config-mutating commands now notify the daemon after durable writes and warn on notification failure.
 - `jin sink enable/disable` now participates in the reload notification path without mutating runtime pause state directly.
-- `jin sink enable/disable --yes` now has controlled-restart parity with other config-mutating sink commands.
+- Config-mutating commands now use `--restart` for explicit controlled restart behavior.
 - Existing config mutations and live reload now reject invalid sink/route/watch generations instead of silently normalizing malformed entries away.
 - Startup now rejects invalid existing config instead of normalizing it into the live generation.
 - Invalid live reload now stops without running shutdown final-flush against stale sinks/routes.
-- Active push work now checks durable sink enablement before each local batch, so disabling a sink stops remaining local batches after any already-in-flight batch.
+- Active push work now checks current sink existence, sink enablement, and current routes before each local batch, so route/sink removal or disable stops remaining local batches after any already-in-flight batch.
+- Config reload now enqueues push so added or retargeted sinks recompute existing backlog immediately under the new config generation.
+- In-flight push batches no longer record local success if the config generation changed before the sink result returned.
+- Sink add health checks now run before acquiring the config write lock; the lock-protected section re-checks identity conflicts before writing.
 - BP-08 and the config mutation Mermaid source clarify accepted-vs-completed reload semantics.
-- Pasteur review findings were addressed: direct sink pause mutation removed, `--yes` parity added, and strict runtime config generation validation added.
-- Rawls/Euler review findings were addressed: startup strict validation, no-flush fatal reload shutdown, active push batch gating, and route help `--yes` visibility.
+- Pasteur review findings were addressed: direct sink pause mutation removed, `--restart` parity added, and strict runtime config generation validation added.
+- Rawls/Euler review findings were addressed: startup strict validation, no-flush fatal reload shutdown, active push batch gating, and route help `--restart` visibility.
 
 ## Validation
 
@@ -135,4 +152,10 @@ Report changed files, acceptance checks, BP matrix result, V1 comparison, and an
 - `bun test test/config.test.ts test/config-mutation-control.test.ts`
 - `bun test test/pipeline-spine.test.ts test/runtime-store-cutover.test.ts`
 - `bun run test:release-gates`
-- Disposable real-daemon smoke: `bun /private/tmp/jin-midrun-reload-smoke.ts ./jin .`
+- CI unit matrix command from `.github/workflows/ci.yml`
+- `bun run test`
+- `bun run test:integration`
+- `bun run test:all`
+- `bun build ./src/index.ts --compile --outfile /private/tmp/jin-validate`
+- `bun run test/acceptance/verify.ts /private/tmp/jin-validate`
+- Earlier disposable real-daemon smoke for the base reload lane: `bun /private/tmp/jin-midrun-reload-smoke.ts ./jin .`

--- a/docs/execution/tasks/W4-CONFIG-02-runtime-reload-status.md
+++ b/docs/execution/tasks/W4-CONFIG-02-runtime-reload-status.md
@@ -1,0 +1,129 @@
+# W4-CONFIG-02 - Runtime Reload And Queue Status
+
+Status: queued
+Owner: worker
+Branch: fix/config-mutation-boundary-19
+
+## Role
+
+Expose durable, immutable runtime status for config reload and pipeline queue state through Jin's daemon-owned status boundary.
+
+## Goal
+
+Operators, CLI commands, Desktop, and tests need to know whether a config reload was accepted, is pending, completed, failed, or is waiting behind other work. Add a stable status snapshot rather than exposing mutable queue internals or relying on log scraping.
+
+## Depends On
+
+- `docs/ontology.md`
+- `docs/blueprint/BP-07-process-lifecycle.md`
+- `docs/blueprint/BP-08-routing-and-config.md`
+- W4-CONFIG-01 reload control route shape
+- Current branch `config-reload` pipeline work item
+
+## Unblocks
+
+- Clear CLI messaging after config mutation
+- Desktop runtime status without direct store or process introspection
+- Better debugging for slow reload/backfill/sink push behavior
+- Future `jin sink repush` progress visibility
+
+## Read In Order
+
+1. `docs/execution/00-global-rules.md`
+2. `docs/execution/01-dispatch-protocol.md`
+3. `docs/execution/05-live-control-plane.md`
+4. `docs/ontology.md`
+5. `docs/blueprint/BP-07-process-lifecycle.md`
+6. `docs/blueprint/BP-08-routing-and-config.md`
+7. `src/pipeline/types.ts`
+8. `src/pipeline/queue.ts`
+9. `src/pipeline/loop.ts`
+10. `src/commands/watch.ts`
+11. `src/commands/status.ts`
+12. `src/api/control.ts`
+13. `src/api/routes.ts`
+14. `test/pipeline-spine.test.ts`
+15. `test/local-control-boundary.test.ts`
+
+## Owned Files
+
+- `src/pipeline/types.ts`
+- `src/pipeline/queue.ts`
+- `src/pipeline/loop.ts`
+- `src/commands/watch.ts`
+- `src/commands/status.ts`
+- `src/api/control.ts`
+- `src/api/routes.ts`
+- `src/contracts/desktop.ts` if status DTOs are shared with Desktop
+- `test/pipeline-spine.test.ts`
+- `test/local-control-boundary.test.ts`
+- A new focused test file under `test/` if needed
+- `docs/blueprint/BP-07-process-lifecycle.md`
+- `docs/blueprint/BP-08-routing-and-config.md`
+
+## Forbidden Boundaries
+
+- Do not change config mutation command behavior; W4-CONFIG-01 owns that.
+- Do not expose mutable queue objects or sink instances.
+- Do not add Desktop-only status contracts for runtime data that the CLI also needs.
+- Do not alter sink push, adapter ingestion, or store schema behavior.
+- Do not introduce polling-only correctness where the daemon can provide a direct accepted/completed signal.
+
+## Required Design
+
+- Add an immutable runtime snapshot API for pipeline state.
+- Snapshot should include enough information to answer: current work item type, queued work item counts/types, last config reload attempt, last config reload success/failure, active config generation or observed config mtime/hash if available, and whether a reload is pending.
+- The snapshot must be safe to serialize through the local API and `jin status --json`.
+- The snapshot must not leak secrets from config or sink connection strings.
+- The snapshot must be compatible with W4-CONFIG-01 reload acknowledgements.
+- Prefer small typed DTOs over ad hoc `Record<string, unknown>` payloads.
+- Treat W4-CONFIG-01 `202` responses as accepted/enqueued/coalesced only; completed/succeeded/failed belongs to this snapshot.
+
+## Recommended Snapshot Fields
+
+- `generatedAt`
+- `stopping`
+- `currentWork`
+- `queue.pendingCount`
+- `queue.pendingByKind`
+- `queue.pending`
+- `config.generation`
+- `config.loadedAt`
+- `config.configMtimeMs`
+- `configReload.state`
+- `configReload.pending`
+- `configReload.current`
+- `configReload.lastAttempt`
+- `configReload.lastSuccess`
+- `configReload.lastFailure`
+
+Omit raw config, sink connection strings, webhook headers, S3 credentials, auth tokens, and filesystem change paths. If a config fingerprint is added, it must be generated from a redacted canonical representation.
+
+## Acceptance Checks
+
+- `bun run typecheck`
+- `bun test test/pipeline-spine.test.ts test/local-control-boundary.test.ts`
+- A focused test proving queue snapshots are immutable copies.
+- A focused test proving config reload state transitions are visible after enqueue and after success/failure.
+- A focused test proving status output does not leak sink connection strings or config secrets.
+
+## BP Acceptance Matrix
+
+| BP | Requirement | Evidence |
+| --- | --- | --- |
+| BP-07 | Desktop reads runtime state through daemon-owned APIs. | Status snapshot is available through local API contracts. |
+| BP-07 | Runtime status is platform-neutral except transport details. | Snapshot DTO is not Unix-socket-specific. |
+| BP-08 | Config reload is coordinator-owned and observable. | Snapshot reports pending/current/last reload state from pipeline loop. |
+| BP-08 | Config secrets remain private. | Snapshot omits raw config and sink credentials. |
+
+## V1 Comparison
+
+V1-era status was largely process/config/store oriented. This packet adds explicit runtime operation state as a v2 capability. That is an intentional extension because live config reload, Desktop, and future repush flows need a reliable control-plane status surface.
+
+## Stop And Escalate
+
+Stop if the status shape needs to become a public stable API beyond local daemon clients. That requires a BP-07/BP-08 contract decision before implementation.
+
+## Completion Report
+
+Report changed files, acceptance checks, BP matrix result, V1 comparison, and any status fields intentionally deferred.

--- a/docs/solutions/2026-05-14-isolate-bun-module-mock-tests.md
+++ b/docs/solutions/2026-05-14-isolate-bun-module-mock-tests.md
@@ -1,0 +1,60 @@
+---
+title: Isolate Bun module mock tests
+date: 2026-05-14
+tags: [testing, bun, ci, integration]
+related: [W4-CONFIG-01]
+---
+
+# Isolate Bun Module Mock Tests
+
+## Problem
+
+Raw `bun test` runs every test file in one Bun test process. Jin has several
+focused command/lifecycle tests that use top-level `mock.module()` with partial
+module replacements. Those replacements are process-global, so unrelated test
+files can import stale partial mocks and fail for reasons unrelated to product
+behavior.
+
+The same raw run also pulled the local Postgres persona test into the unit
+surface. That test requires a Docker-backed database on `localhost:5444`, so it
+should be an explicit integration gate rather than an accidental unit-test side
+effect.
+
+## Solution
+
+Add an isolated test runner at `scripts/test.ts`:
+
+- `bun run test` runs every non-integration `.test.ts` file in its own Bun
+  process.
+- `bun run test:integration` starts the Docker Postgres service, runs the
+  persona Postgres test, and tears the service down.
+- `bun run test:all` runs the isolated unit suite plus the Docker-backed
+  integration suite.
+
+The leaking mock-heavy files also restore mocks at suite end, and the runtime
+cutover updater mock now exports `VERSION` so any accidental overlap is less
+fragile.
+
+## Key Insight
+
+For Bun, top-level `mock.module()` is not a file-local isolation boundary.
+Tests that mock command/runtime modules should either run in separate processes
+or avoid partial module mocks. Process isolation is the least surprising default
+for Jin because many tests intentionally mock singleton runtime modules.
+
+## Prevention
+
+Use `bun run test` for local unit validation instead of raw `bun test`. Use
+`bun run test:integration` when validating the Postgres persona path. If a new
+test adds top-level module mocks, make sure it passes through the isolated
+runner and does not rely on global ordering with other files.
+
+## Related
+
+- `W4-CONFIG-01` config mutation and push cutover validation
+
+## Files Changed
+
+- `scripts/test.ts`
+- `package.json`
+- `test/*` mock-heavy command/runtime tests

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "jin": "./src/index.ts"
   },
   "scripts": {
-    "test": "bun test",
+    "test": "bun run scripts/test.ts unit",
     "test:release-gates": "bun test test/lifecycle-boundary.test.ts test/local-control-boundary.test.ts test/runtime-state-local-owner.test.ts",
     "dev": "bun run src/index.ts",
     "build": "bun build ./src/index.ts --compile --outfile jin",
@@ -16,7 +16,8 @@
     "desktop:start": "bun run desktop:build && electron desktop/dist/main.js",
     "desktop:typecheck": "tsc -p desktop/tsconfig.json --noEmit",
     "typecheck": "tsc --noEmit",
-    "test:integration": "/bin/sh -c 'docker compose -f test/docker-compose.integration.yml up -d --wait postgres && bun test test/persona-local-postgres.test.ts; status=$?; docker compose -f test/docker-compose.integration.yml down -v; exit $status'"
+    "test:integration": "bun run scripts/test.ts integration",
+    "test:all": "bun run scripts/test.ts all"
   },
   "dependencies": {},
   "devDependencies": {

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -1,0 +1,115 @@
+import { readdir } from "fs/promises";
+import { join, relative } from "path";
+
+const INTEGRATION_TESTS = new Set([
+  "test/persona-local-postgres.test.ts",
+]);
+const POSTGRES_COMPOSE_FILE = "test/docker-compose.integration.yml";
+
+type Mode = "unit" | "integration" | "all";
+
+const mode = parseMode(process.argv[2]);
+
+try {
+  if (mode === "unit" || mode === "all") {
+    const unitTests = (await findTestFiles("test")).filter(
+      (file) => !INTEGRATION_TESTS.has(file),
+    );
+    await runTestFiles(unitTests);
+  }
+
+  if (mode === "integration" || mode === "all") {
+    await runIntegrationTests();
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+}
+
+function parseMode(value: string | undefined): Mode {
+  if (!value) {
+    return "unit";
+  }
+
+  if (value === "unit" || value === "integration" || value === "all") {
+    return value;
+  }
+
+  throw new Error(`Unknown test mode "${value}". Use unit, integration, or all.`);
+}
+
+async function findTestFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await findTestFiles(path));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith(".test.ts")) {
+      files.push(relative(process.cwd(), path));
+    }
+  }
+
+  return files.sort();
+}
+
+async function runTestFiles(files: string[]): Promise<void> {
+  for (const file of files) {
+    await run(["bun", "test", file]);
+  }
+}
+
+async function runIntegrationTests(): Promise<void> {
+  await run([
+    "docker",
+    "compose",
+    "-f",
+    POSTGRES_COMPOSE_FILE,
+    "up",
+    "-d",
+    "--wait",
+    "postgres",
+  ]);
+
+  let status = 0;
+  try {
+    for (const file of INTEGRATION_TESTS) {
+      await run(["bun", "test", file]);
+    }
+  } catch (error) {
+    status = 1;
+    console.error(error instanceof Error ? error.message : String(error));
+  } finally {
+    await run([
+      "docker",
+      "compose",
+      "-f",
+      POSTGRES_COMPOSE_FILE,
+      "down",
+      "-v",
+    ]);
+  }
+
+  if (status !== 0) {
+    throw new Error("Integration tests failed.");
+  }
+}
+
+async function run(cmd: string[]): Promise<void> {
+  console.log(`\n$ ${cmd.join(" ")}`);
+  const proc = Bun.spawn({
+    cmd,
+    cwd: process.cwd(),
+    env: process.env,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error(`${cmd.join(" ")} exited with ${exitCode}`);
+  }
+}

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,134 @@
+import { getRuntimePaths } from "../daemon/runtime-state";
+import { DESKTOP_AUTH_HEADER, getDesktopApiToken } from "./auth";
+
+export type ConfigReloadNotificationResult =
+  | {
+      status: "accepted";
+      statusCode: number;
+      message: string;
+    }
+  | {
+      status: "rejected";
+      statusCode: number;
+      message: string;
+    }
+  | {
+      status: "failed";
+      message: string;
+    };
+
+export interface RequestConfigReloadOptions {
+  endpoint?: string;
+  fetch?: typeof fetch;
+  token?: string;
+  timeoutMs?: number;
+}
+
+interface BunUnixRequestInit extends RequestInit {
+  unix?: string;
+}
+
+const DEFAULT_RELOAD_REQUEST_TIMEOUT_MS = 2_000;
+
+export async function requestDaemonConfigReload(
+  options: RequestConfigReloadOptions = {},
+): Promise<ConfigReloadNotificationResult> {
+  const endpoint = options.endpoint ?? getRuntimePaths().localEndpoint;
+  const token = options.token ?? getDesktopApiToken();
+  const fetchImpl = options.fetch ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort(new Error("local daemon API request timed out"));
+  }, options.timeoutMs ?? DEFAULT_RELOAD_REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetchImpl(
+      buildLocalApiUrl(endpoint, "/api/control/config/reload"),
+      buildRequestInit(endpoint, token, controller.signal),
+    );
+    const payload = await readJsonObject(response);
+    const message = readPayloadMessage(payload) ?? response.statusText;
+
+    if (response.ok && payload?.accepted === true) {
+      return {
+        status: "accepted",
+        statusCode: response.status,
+        message: message || "Config reload accepted.",
+      };
+    }
+
+    return {
+      status: "rejected",
+      statusCode: response.status,
+      message:
+        message ||
+        `Config reload request was rejected with HTTP ${response.status}.`,
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      message: formatError(error),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function buildRequestInit(
+  endpoint: string,
+  token: string,
+  signal: AbortSignal,
+): BunUnixRequestInit {
+  const init: BunUnixRequestInit = {
+    method: "POST",
+    signal,
+    headers: {
+      [DESKTOP_AUTH_HEADER]: token,
+    },
+  };
+
+  if (!isHttpEndpoint(endpoint)) {
+    init.unix = endpoint;
+  }
+
+  return init;
+}
+
+function buildLocalApiUrl(endpoint: string, path: string): string {
+  if (isHttpEndpoint(endpoint)) {
+    return new URL(path, endpoint).toString();
+  }
+
+  return `http://localhost${path}`;
+}
+
+function isHttpEndpoint(endpoint: string): boolean {
+  return endpoint.startsWith("http://") || endpoint.startsWith("https://");
+}
+
+async function readJsonObject(
+  response: Response,
+): Promise<Record<string, any> | null> {
+  try {
+    const payload = await response.json();
+    return isRecord(payload) ? payload : null;
+  } catch {
+    return null;
+  }
+}
+
+function readPayloadMessage(payload: Record<string, any> | null): string | null {
+  const message = payload?.message ?? payload?.error;
+  return typeof message === "string" && message.length > 0 ? message : null;
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === "object" && value !== null;
+}
+
+function formatError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}

--- a/src/api/control.ts
+++ b/src/api/control.ts
@@ -26,10 +26,22 @@ export type LocalControlHealthStatus = DesktopHealthStatus;
 export type LocalControlComponentDto = DesktopControlComponent;
 export type LocalControlStatusDto = DesktopControlStatus;
 export type LocalControlActionResultDto = DesktopControlActionResult;
+export type LocalConfigReloadSource = "command";
+
+export interface LocalConfigReloadResultDto {
+  action: "config-reload";
+  ok: boolean;
+  accepted: boolean;
+  source: LocalConfigReloadSource;
+  message: string;
+}
 
 export interface LocalControlBoundary {
   getStatus(): LocalControlStatusDto;
   runAction(action: LocalControlAction): Promise<LocalControlActionResultDto>;
+  reloadConfig?(
+    source?: LocalConfigReloadSource,
+  ): Promise<LocalConfigReloadResultDto>;
 }
 
 export interface LocalControlBoundaryOptions {
@@ -37,6 +49,9 @@ export interface LocalControlBoundaryOptions {
     action: LocalControlAction,
   ) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
   getStatus?: () => LocalControlStatusDto;
+  requestConfigReload?: (
+    source: LocalConfigReloadSource,
+  ) => boolean | Promise<boolean>;
 }
 
 export interface LifecycleCommandOptions {
@@ -53,6 +68,7 @@ export function createLocalControlBoundary(
 ): LocalControlBoundary {
   const executeAction = options.executeAction ?? executeLifecycleAction;
   const getStatus = options.getStatus ?? getLocalControlStatus;
+  const requestConfigReload = options.requestConfigReload;
 
   return {
     getStatus,
@@ -65,6 +81,38 @@ export function createLocalControlBoundary(
         stdout: result.stdout.trim(),
         stderr: result.stderr.trim(),
         status: getStatus(),
+      };
+    },
+    async reloadConfig(source = "command") {
+      if (!requestConfigReload) {
+        return {
+          action: "config-reload",
+          ok: false,
+          accepted: false,
+          source,
+          message:
+            "Config reload is unavailable because the local control boundary is not attached to a running pipeline.",
+        };
+      }
+
+      const accepted = await requestConfigReload(source);
+      if (!accepted) {
+        return {
+          action: "config-reload",
+          ok: false,
+          accepted: false,
+          source,
+          message:
+            "Config reload was not accepted because the runtime is stopping.",
+        };
+      }
+
+      return {
+        action: "config-reload",
+        ok: true,
+        accepted: true,
+        source,
+        message: "Config reload accepted.",
       };
     },
   };

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -88,6 +88,18 @@ export function createRoutes(
     return json(result, result.ok ? 200 : 409);
   });
 
+  routes.set("POST /api/control/config/reload", async () => {
+    if (!controlBoundary.reloadConfig) {
+      return json(
+        { error: "Config reload is not available for this runtime." },
+        409,
+      );
+    }
+
+    const result = await controlBoundary.reloadConfig("command");
+    return json(result, result.accepted ? 202 : 409);
+  });
+
   routes.set("GET /api/desktop/compatibility", () => {
     return json(buildDesktopCompatibilityInfo());
   });

--- a/src/commands/config-control.ts
+++ b/src/commands/config-control.ts
@@ -34,8 +34,8 @@ export async function finalizeConfigChange(
   }
 
   if (!opts.yes) {
-    console.log("  Restart jin to apply config changes.");
-    console.log("  Re-run with `--yes` to perform a controlled restart now.");
+    console.log("  Running runtime will reload config shortly.");
+    console.log("  Re-run with `--yes` to force a full controlled restart instead.");
     return;
   }
 

--- a/src/commands/config-control.ts
+++ b/src/commands/config-control.ts
@@ -14,7 +14,15 @@ export async function persistConfigChange(
   } = {},
 ): Promise<void> {
   await saveConfig(config);
+  await finalizeConfigChange(opts);
+}
 
+export async function finalizeConfigChange(
+  opts: {
+    yes?: boolean;
+    changeSummary?: string;
+  } = {},
+): Promise<void> {
   if (opts.changeSummary) {
     console.log(`  ${opts.changeSummary}.`);
   }

--- a/src/commands/config-control.ts
+++ b/src/commands/config-control.ts
@@ -1,10 +1,8 @@
 import { saveConfig, type JinConfig } from "../config";
-import type { RuntimeIssue } from "../contracts/lifecycle";
+import { requestDaemonConfigReload } from "../api/client";
 import { getWatcherState } from "../daemon/process-state";
-import { getRuntimeStatus, markRuntimeRunning } from "../daemon/runtime-state";
+import { getRuntimeStatus } from "../daemon/runtime-state";
 import { restartCommand } from "./start";
-
-const OPERATOR_PAUSE_PREFIX = "sink paused by operator:";
 
 export async function persistConfigChange(
   config: JinConfig,
@@ -28,56 +26,42 @@ export async function finalizeConfigChange(
   }
 
   const watcher = getWatcherState();
-  if (watcher.status !== "running") {
+  const runtime = getRuntimeStatus();
+  if (!isRuntimeExpectedToReloadConfig(runtime, watcher)) {
     console.log("  Changes will apply the next time jin starts.");
     return;
   }
 
-  if (!opts.yes) {
-    console.log("  Running runtime will reload config shortly.");
+  if (opts.yes) {
+    console.log("  Restarting jin to apply config changes...");
+    await restartCommand({
+      ...(runtime.owner?.mode === "service" ? { service: true } : {}),
+    });
+    return;
+  }
+
+  const reloadResult = await requestDaemonConfigReload();
+  if (reloadResult.status === "accepted") {
+    console.log("  Running runtime accepted config reload request.");
     console.log("  Re-run with `--yes` to force a full controlled restart instead.");
     return;
   }
 
-  console.log("  Restarting jin to apply config changes...");
-  const runtime = getRuntimeStatus();
-  await restartCommand({
-    ...(runtime.owner?.mode === "service" ? { service: true } : {}),
-  });
-}
-
-export function applySinkPauseControl(
-  sinkId: string,
-  paused: boolean,
-): boolean {
-  const runtime = getRuntimeStatus();
-  if (
-    !runtime.owner ||
-    (runtime.state !== "running" && runtime.state !== "degraded")
-  ) {
-    return false;
-  }
-
-  const nextIssues = runtime.issues.filter(
-    (issue) => !isOperatorPauseIssue(issue, sinkId),
+  console.log(
+    `  WARNING: Config saved, but jin could not notify the running runtime to reload: ${reloadResult.message}`,
   );
+  console.log(
+    "  File watcher fallback will try to apply the change; otherwise restart jin.",
+  );
+}
 
-  if (paused) {
-    nextIssues.push({
-      subsystem: "push",
-      message: operatorPauseMessage(sinkId),
-      paused: true,
-    });
+function isRuntimeExpectedToReloadConfig(
+  runtime: ReturnType<typeof getRuntimeStatus>,
+  watcher: ReturnType<typeof getWatcherState>,
+): boolean {
+  if (runtime.owner && runtime.state !== "stopped" && runtime.state !== "stopping") {
+    return true;
   }
 
-  markRuntimeRunning(runtime.owner.mode, nextIssues);
-  return true;
-}
-
-function operatorPauseMessage(sinkId: string): string {
-  return `${OPERATOR_PAUSE_PREFIX} ${sinkId}`;
-}
-
-function isOperatorPauseIssue(issue: RuntimeIssue, sinkId: string): boolean {
-  return issue.message === operatorPauseMessage(sinkId);
+  return watcher.status === "running";
 }

--- a/src/commands/config-control.ts
+++ b/src/commands/config-control.ts
@@ -7,7 +7,7 @@ import { restartCommand } from "./start";
 export async function persistConfigChange(
   config: JinConfig,
   opts: {
-    yes?: boolean;
+    restart?: boolean;
     changeSummary?: string;
   } = {},
 ): Promise<void> {
@@ -17,7 +17,7 @@ export async function persistConfigChange(
 
 export async function finalizeConfigChange(
   opts: {
-    yes?: boolean;
+    restart?: boolean;
     changeSummary?: string;
   } = {},
 ): Promise<void> {
@@ -32,7 +32,7 @@ export async function finalizeConfigChange(
     return;
   }
 
-  if (opts.yes) {
+  if (opts.restart) {
     console.log("  Restarting jin to apply config changes...");
     await restartCommand({
       ...(runtime.owner?.mode === "service" ? { service: true } : {}),
@@ -43,7 +43,7 @@ export async function finalizeConfigChange(
   const reloadResult = await requestDaemonConfigReload();
   if (reloadResult.status === "accepted") {
     console.log("  Running runtime accepted config reload request.");
-    console.log("  Re-run with `--yes` to force a full controlled restart instead.");
+    console.log("  Re-run with `--restart` to force a full controlled restart instead.");
     return;
   }
 

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -3,7 +3,7 @@ import { homedir } from "os";
 import {
   ensureConfigDir,
   loadConfig,
-  saveConfig,
+  updateConfig,
   type JinConfig,
   type SinkConfig,
 } from "../config";
@@ -18,7 +18,7 @@ import {
   findSinkIndexById,
   type SinkCandidateInput,
 } from "./sink";
-import { persistConfigChange } from "./config-control";
+import { finalizeConfigChange } from "./config-control";
 import { normalizeRemote, sinkIdsForConversation } from "../routing";
 import { decodeTeamConfig, type SinkConfig as TeamSinkConfig } from "../sinks/types";
 import { getRuntimePaths } from "../daemon/runtime-state";
@@ -69,11 +69,17 @@ export async function connectCommand(
   if (!project && !opts.remote) {
     if (opts.team) {
       ensureConfigDir();
-      const config = await loadConfig();
-      const sinkResult = await resolveOrCreateSink(config, opts);
+      const { result: sinkResult } = await updateConfig(
+        (config) => resolveOrCreateSink(config, opts),
+        {
+          shouldSave: (result) => result.created,
+        },
+      );
       if (sinkResult.created) {
-        await saveConfig(config);
-        console.log(`  Added sink: ${sinkDisplayLabel(sinkResult.sink)}`);
+        await finalizeConfigChange({
+          yes: opts.yes,
+          changeSummary: `Added sink ${sinkDisplayLabel(sinkResult.sink)}`,
+        });
       } else {
         console.log(`  Sink already configured (${sinkResult.sinkId})`);
       }
@@ -101,10 +107,19 @@ export async function connectCommand(
   }
 
   ensureConfigDir();
-  const config = await loadConfig();
-  const sinkResult = await resolveOrCreateSink(config, opts);
   const routeTarget = resolveConnectTarget(project, opts);
-  const routeResult = upsertRoute(config, routeTarget.match, [sinkResult.sinkId]);
+  const { result } = await updateConfig(
+    async (config) => {
+      const sinkResult = await resolveOrCreateSink(config, opts);
+      const routeResult = upsertRoute(config, routeTarget.match, [sinkResult.sinkId]);
+      return { sinkResult, routeResult };
+    },
+    {
+      shouldSave: ({ sinkResult, routeResult }) =>
+        sinkResult.created || routeResult.changed,
+    },
+  );
+  const { sinkResult, routeResult } = result;
 
   if (!sinkResult.created && !routeResult.changed) {
     console.log(
@@ -113,7 +128,7 @@ export async function connectCommand(
     return;
   }
 
-  await persistConfigChange(config, {
+  await finalizeConfigChange({
     yes: opts.yes,
     changeSummary: `${
       routeResult.created ? "Connected" : "Updated"
@@ -333,36 +348,48 @@ export async function disconnectCommand(
     ]);
   }
 
-  const config = await loadConfig();
   const target = resolveProjectTarget(project);
   const match = normalizeRouteMatchInput(target.match);
-  const route = config.routes.find((candidate) => matchesExactRoute(candidate.match, match));
-  if (!route) {
-    fail(`no connection found for "${project}"`, [
-      "  Run 'jin connections' to see current connections.",
-    ]);
-  }
+  const { result } = await updateConfig((config) => {
+    const route = config.routes.find((candidate) => matchesExactRoute(candidate.match, match));
+    if (!route) {
+      fail(`no connection found for "${project}"`, [
+        "  Run 'jin connections' to see current connections.",
+      ]);
+    }
 
-  const removedSinkIds = [...route.sinks];
-  removeRoute(config, match);
+    const removedSinkIds = [...route.sinks];
+    removeRoute(config, match);
+    const keptSinks: string[] = [];
+    const removedSinks: string[] = [];
 
-  if (opts["remove-sink"] || opts.removeSink) {
-    for (const sinkId of removedSinkIds) {
-      const stillUsed = config.routes.some((candidate) => candidate.sinks.includes(sinkId));
-      if (stillUsed) {
-        console.log(`  Sink ${sinkId} is still used by other routes, kept.`);
-        continue;
-      }
+    if (opts["remove-sink"] || opts.removeSink) {
+      for (const sinkId of removedSinkIds) {
+        const stillUsed = config.routes.some((candidate) => candidate.sinks.includes(sinkId));
+        if (stillUsed) {
+          keptSinks.push(sinkId);
+          continue;
+        }
 
-      const sinkIndex = findSinkIndexById(config, sinkId);
-      if (sinkIndex >= 0) {
-        config.sinks.splice(sinkIndex, 1);
-        console.log(`  Removed sink: ${sinkId}`);
+        const sinkIndex = findSinkIndexById(config, sinkId);
+        if (sinkIndex >= 0) {
+          config.sinks.splice(sinkIndex, 1);
+          removedSinks.push(sinkId);
+        }
       }
     }
+
+    return { keptSinks, removedSinks };
+  });
+
+  for (const sinkId of result.keptSinks) {
+    console.log(`  Sink ${sinkId} is still used by other routes, kept.`);
+  }
+  for (const sinkId of result.removedSinks) {
+    console.log(`  Removed sink: ${sinkId}`);
   }
 
-  await persistConfigChange(config, {
+  await finalizeConfigChange({
     yes: opts.yes,
     changeSummary: `Disconnected ${project} (${formatRouteMatch(match)})`,
   });

--- a/src/commands/connect.ts
+++ b/src/commands/connect.ts
@@ -16,6 +16,7 @@ import {
 import {
   ensureSinkConfigured,
   findSinkIndexById,
+  preflightSinkCandidate,
   type SinkCandidateInput,
 } from "./sink";
 import { finalizeConfigChange } from "./config-control";
@@ -33,7 +34,7 @@ interface ConnectOptions {
   userId?: string;
   remote?: string;
   json?: boolean;
-  yes?: boolean;
+  restart?: boolean;
 }
 
 interface ProjectRow {
@@ -69,15 +70,16 @@ export async function connectCommand(
   if (!project && !opts.remote) {
     if (opts.team) {
       ensureConfigDir();
+      await preflightTeamSink(opts);
       const { result: sinkResult } = await updateConfig(
-        (config) => resolveOrCreateSink(config, opts),
+        (config) => resolveOrCreateSink(config, opts, { validateSink: false }),
         {
           shouldSave: (result) => result.created,
         },
       );
       if (sinkResult.created) {
         await finalizeConfigChange({
-          yes: opts.yes,
+          restart: opts.restart,
           changeSummary: `Added sink ${sinkDisplayLabel(sinkResult.sink)}`,
         });
       } else {
@@ -108,9 +110,12 @@ export async function connectCommand(
 
   ensureConfigDir();
   const routeTarget = resolveConnectTarget(project, opts);
+  await preflightTeamSink(opts);
   const { result } = await updateConfig(
     async (config) => {
-      const sinkResult = await resolveOrCreateSink(config, opts);
+      const sinkResult = await resolveOrCreateSink(config, opts, {
+        validateSink: false,
+      });
       const routeResult = upsertRoute(config, routeTarget.match, [sinkResult.sinkId]);
       return { sinkResult, routeResult };
     },
@@ -129,7 +134,7 @@ export async function connectCommand(
   }
 
   await finalizeConfigChange({
-    yes: opts.yes,
+    restart: opts.restart,
     changeSummary: `${
       routeResult.created ? "Connected" : "Updated"
     } ${routeTarget.label} -> ${sinkDisplayLabel(sinkResult.sink)}`,
@@ -340,7 +345,7 @@ export async function connectionsCommand(): Promise<void> {
 
 export async function disconnectCommand(
   project: string,
-  opts: { "remove-sink"?: boolean; removeSink?: boolean; yes?: boolean },
+  opts: { "remove-sink"?: boolean; removeSink?: boolean; restart?: boolean },
 ): Promise<void> {
   if (!project) {
     fail("specify a project to disconnect", [
@@ -390,7 +395,7 @@ export async function disconnectCommand(
   }
 
   await finalizeConfigChange({
-    yes: opts.yes,
+    restart: opts.restart,
     changeSummary: `Disconnected ${project} (${formatRouteMatch(match)})`,
   });
 }
@@ -484,6 +489,7 @@ function sinkDisplayLabel(sink: SinkConfig): string {
 async function resolveOrCreateSink(
   config: JinConfig,
   opts: ConnectOptions,
+  options: { validateSink?: boolean } = {},
 ): Promise<{ sinkId: string; created: boolean; sink: SinkConfig }> {
   if (opts.sink) {
     const sinkIndex = findSinkIndexById(config, opts.sink);
@@ -502,7 +508,9 @@ async function resolveOrCreateSink(
 
   if (opts.team) {
     const decoded = decodeTeamConfig(opts.team);
-    return ensureSinkConfigured(config, toSinkCandidate(decoded, opts));
+    return ensureSinkConfigured(config, toSinkCandidate(decoded, opts), {
+      validate: options.validateSink,
+    });
   }
 
   fail("specify a sink type or existing sink", [
@@ -513,6 +521,15 @@ async function resolveOrCreateSink(
     "    jin sink add <type> ...",
     '    jin route add --remote="github.com/org/repo" --sink=<id>',
   ]);
+}
+
+async function preflightTeamSink(opts: ConnectOptions): Promise<void> {
+  if (!opts.team || opts.sink) {
+    return;
+  }
+
+  const decoded = decodeTeamConfig(opts.team);
+  await preflightSinkCandidate(toSinkCandidate(decoded, opts));
 }
 
 function toSinkCandidate(

--- a/src/commands/route.ts
+++ b/src/commands/route.ts
@@ -1,6 +1,6 @@
-import { loadConfig, type JinConfig, type RouteMatch } from "../config";
+import { updateConfig, type JinConfig, type RouteMatch } from "../config";
 import { normalizeAdapterId, normalizeRemote } from "../routing";
-import { persistConfigChange } from "./config-control";
+import { finalizeConfigChange } from "./config-control";
 import { findSinkIndexById } from "./sink";
 
 export interface RouteCommandOptions {
@@ -19,12 +19,18 @@ export async function routeAddCommand(
     fail("route add requires --sink");
   }
 
-  const config = await loadConfig();
-  if (findSinkIndexById(config, opts.sink) === -1) {
-    fail(`sink "${opts.sink}" not found`);
-  }
+  const { result } = await updateConfig(
+    (config) => {
+      if (findSinkIndexById(config, opts.sink!) === -1) {
+        fail(`sink "${opts.sink}" not found`);
+      }
 
-  const result = upsertRoute(config, opts, [opts.sink]);
+      return upsertRoute(config, opts, [opts.sink!]);
+    },
+    {
+      shouldSave: (result) => result.changed,
+    },
+  );
   if (!result.changed) {
     console.log(
       `  Route ${formatRouteMatch(result.match)} already includes ${opts.sink}.`,
@@ -32,7 +38,7 @@ export async function routeAddCommand(
     return;
   }
 
-  await persistConfigChange(config, {
+  await finalizeConfigChange({
     yes: opts.yes,
     changeSummary: `${result.created ? "Added" : "Updated"} route ${formatRouteMatch(result.match)}`,
   });
@@ -41,13 +47,17 @@ export async function routeAddCommand(
 export async function routeRemoveCommand(
   opts: RouteCommandOptions,
 ): Promise<void> {
-  const config = await loadConfig();
-  const result = removeRoute(config, opts, opts.sink);
+  const { result } = await updateConfig(
+    (config) => removeRoute(config, opts, opts.sink),
+    {
+      shouldSave: (result) => result.changed,
+    },
+  );
   if (!result.changed) {
     fail(`route ${formatRouteMatch(result.match)} not found`);
   }
 
-  await persistConfigChange(config, {
+  await finalizeConfigChange({
     yes: opts.yes,
     changeSummary: `Removed route target from ${formatRouteMatch(result.match)}`,
   });

--- a/src/commands/route.ts
+++ b/src/commands/route.ts
@@ -9,7 +9,7 @@ export interface RouteCommandOptions {
   adapter?: string;
   branch?: string;
   name?: string;
-  yes?: boolean;
+  restart?: boolean;
 }
 
 export async function routeAddCommand(
@@ -39,7 +39,7 @@ export async function routeAddCommand(
   }
 
   await finalizeConfigChange({
-    yes: opts.yes,
+    restart: opts.restart,
     changeSummary: `${result.created ? "Added" : "Updated"} route ${formatRouteMatch(result.match)}`,
   });
 }
@@ -58,7 +58,7 @@ export async function routeRemoveCommand(
   }
 
   await finalizeConfigChange({
-    yes: opts.yes,
+    restart: opts.restart,
     changeSummary: `Removed route target from ${formatRouteMatch(result.match)}`,
   });
 }

--- a/src/commands/sink.ts
+++ b/src/commands/sink.ts
@@ -23,10 +23,7 @@ import { DiagnosticLogger } from "../pipeline/diagnostic";
 import { pushDirty } from "../pipeline/push";
 import type { PipelineLogger } from "../pipeline/types";
 import { createSink } from "../sinks/registry";
-import {
-  applySinkPauseControl,
-  finalizeConfigChange,
-} from "./config-control";
+import { finalizeConfigChange } from "./config-control";
 import { join } from "path";
 
 export interface SinkCommandOptions {
@@ -119,12 +116,18 @@ export async function sinkRemoveCommand(
   });
 }
 
-export async function sinkDisableCommand(sinkId: string): Promise<void> {
-  await setSinkEnabled(sinkId, false);
+export async function sinkDisableCommand(
+  sinkId: string,
+  opts: { yes?: boolean } = {},
+): Promise<void> {
+  await setSinkEnabled(sinkId, false, opts);
 }
 
-export async function sinkEnableCommand(sinkId: string): Promise<void> {
-  await setSinkEnabled(sinkId, true);
+export async function sinkEnableCommand(
+  sinkId: string,
+  opts: { yes?: boolean } = {},
+): Promise<void> {
+  await setSinkEnabled(sinkId, true, opts);
 }
 
 export async function sinkRepushCommand(sinkId: string): Promise<void> {
@@ -381,7 +384,11 @@ async function validateSink(sinkConfig: SinkConfig, index: number): Promise<void
   }
 }
 
-async function setSinkEnabled(sinkId: string, enabled: boolean): Promise<void> {
+async function setSinkEnabled(
+  sinkId: string,
+  enabled: boolean,
+  opts: { yes?: boolean } = {},
+): Promise<void> {
   if (!sinkId) {
     fail("specify a sink id");
   }
@@ -420,25 +427,18 @@ async function setSinkEnabled(sinkId: string, enabled: boolean): Promise<void> {
     return;
   }
 
-  await persistSinkControlChange(sinkId, enabled);
+  await persistSinkControlChange(sinkId, enabled, opts);
 }
 
 async function persistSinkControlChange(
   sinkId: string,
   enabled: boolean,
+  opts: { yes?: boolean },
 ): Promise<void> {
-  const runtimeUpdated = applySinkPauseControl(sinkId, !enabled);
-  if (enabled) {
-    console.log(`  Sink ${sinkId} enabled.`);
-  } else {
-    console.log(`  Sink ${sinkId} disabled.`);
-  }
-
-  if (runtimeUpdated) {
-    console.log("  Active runtime status updated; config reload will apply shortly.");
-  } else {
-    console.log("  Change saved; it will apply on the next start.");
-  }
+  await finalizeConfigChange({
+    yes: opts.yes,
+    changeSummary: `Sink ${sinkId} ${enabled ? "enabled" : "disabled"}`,
+  });
 }
 
 function createSinkCommandLogger(): PipelineLogger {

--- a/src/commands/sink.ts
+++ b/src/commands/sink.ts
@@ -2,7 +2,7 @@ import {
   DEFAULT_S3_PREFIX,
   DEFAULT_S3_REGION,
   loadConfig,
-  saveConfig,
+  updateConfig,
   type JinConfig,
   type SinkConfig,
 } from "../config";
@@ -23,7 +23,10 @@ import { DiagnosticLogger } from "../pipeline/diagnostic";
 import { pushDirty } from "../pipeline/push";
 import type { PipelineLogger } from "../pipeline/types";
 import { createSink } from "../sinks/registry";
-import { applySinkPauseControl, persistConfigChange } from "./config-control";
+import {
+  applySinkPauseControl,
+  finalizeConfigChange,
+} from "./config-control";
 import { join } from "path";
 
 export interface SinkCommandOptions {
@@ -52,15 +55,19 @@ export async function sinkAddCommand(
   type: SinkType,
   opts: SinkCommandOptions,
 ): Promise<void> {
-  const config = await loadConfig();
-  const result = await ensureSinkConfigured(config, { ...opts, type });
+  const { result } = await updateConfig(
+    (config) => ensureSinkConfigured(config, { ...opts, type }),
+    {
+      shouldSave: (result) => result.created,
+    },
+  );
 
   if (!result.created) {
     console.log(`  Sink already configured: ${result.sinkId}`);
     return;
   }
 
-  await persistConfigChange(config, {
+  await finalizeConfigChange({
     yes: opts.yes,
     changeSummary: `Added sink ${result.sinkId}`,
   });
@@ -77,34 +84,37 @@ export async function sinkRemoveCommand(
     fail("specify a sink id");
   }
 
-  const config = await loadConfig();
-  const sinkIndex = findSinkIndexById(config, sinkId);
-  if (sinkIndex === -1) {
-    fail(`sink "${sinkId}" not found`);
-  }
-
-  config.sinks.splice(sinkIndex, 1);
-
-  let affectedRoutes = 0;
-  config.routes = config.routes.flatMap((route) => {
-    if (!route.sinks.includes(sinkId)) {
-      return [route];
+  const { result } = await updateConfig((config) => {
+    const sinkIndex = findSinkIndexById(config, sinkId);
+    if (sinkIndex === -1) {
+      fail(`sink "${sinkId}" not found`);
     }
 
-    affectedRoutes += 1;
-    const remainingSinks = route.sinks.filter((id) => id !== sinkId);
-    if (remainingSinks.length === 0) {
-      return [];
-    }
+    config.sinks.splice(sinkIndex, 1);
 
-    return [{ ...route, sinks: remainingSinks }];
+    let affectedRoutes = 0;
+    config.routes = config.routes.flatMap((route) => {
+      if (!route.sinks.includes(sinkId)) {
+        return [route];
+      }
+
+      affectedRoutes += 1;
+      const remainingSinks = route.sinks.filter((id) => id !== sinkId);
+      if (remainingSinks.length === 0) {
+        return [];
+      }
+
+      return [{ ...route, sinks: remainingSinks }];
+    });
+
+    return { affectedRoutes };
   });
 
-  await persistConfigChange(config, {
+  await finalizeConfigChange({
     yes: opts.yes,
     changeSummary:
-      affectedRoutes > 0
-        ? `Removed sink ${sinkId} and updated ${affectedRoutes} route${affectedRoutes === 1 ? "" : "s"}`
+      result.affectedRoutes > 0
+        ? `Removed sink ${sinkId} and updated ${result.affectedRoutes} route${result.affectedRoutes === 1 ? "" : "s"}`
         : `Removed sink ${sinkId}`,
   });
 }
@@ -376,15 +386,32 @@ async function setSinkEnabled(sinkId: string, enabled: boolean): Promise<void> {
     fail("specify a sink id");
   }
 
-  const config = await loadConfig();
-  const sinkIndex = findSinkIndexById(config, sinkId);
-  if (sinkIndex === -1) {
-    fail(`sink "${sinkId}" not found`);
-  }
+  const { result } = await updateConfig(
+    (config) => {
+      const sinkIndex = findSinkIndexById(config, sinkId);
+      if (sinkIndex === -1) {
+        fail(`sink "${sinkId}" not found`);
+      }
 
-  const current = config.sinks[sinkIndex];
-  const alreadyEnabled = current.enabled !== false;
-  if (alreadyEnabled === enabled) {
+      const current = config.sinks[sinkIndex];
+      const alreadyEnabled = current.enabled !== false;
+      if (alreadyEnabled === enabled) {
+        return { changed: false };
+      }
+
+      config.sinks[sinkIndex] = {
+        ...current,
+        enabled,
+      };
+
+      return { changed: true };
+    },
+    {
+      shouldSave: (result) => result.changed,
+    },
+  );
+
+  if (!result.changed) {
     console.log(
       enabled
         ? `  Sink ${sinkId} is already enabled.`
@@ -393,21 +420,13 @@ async function setSinkEnabled(sinkId: string, enabled: boolean): Promise<void> {
     return;
   }
 
-  config.sinks[sinkIndex] = {
-    ...current,
-    enabled,
-  };
-
-  await persistSinkControlChange(config, sinkId, enabled);
+  await persistSinkControlChange(sinkId, enabled);
 }
 
 async function persistSinkControlChange(
-  config: JinConfig,
   sinkId: string,
   enabled: boolean,
 ): Promise<void> {
-  await persistConfigOnly(config);
-
   const runtimeUpdated = applySinkPauseControl(sinkId, !enabled);
   if (enabled) {
     console.log(`  Sink ${sinkId} enabled.`);
@@ -420,10 +439,6 @@ async function persistSinkControlChange(
   } else {
     console.log("  Change saved; it will apply on the next start.");
   }
-}
-
-async function persistConfigOnly(config: JinConfig): Promise<void> {
-  await saveConfig(config);
 }
 
 function createSinkCommandLogger(): PipelineLogger {

--- a/src/commands/sink.ts
+++ b/src/commands/sink.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_S3_PREFIX,
   DEFAULT_S3_REGION,
   loadConfig,
+  loadRuntimeConfigGeneration,
   updateConfig,
   type JinConfig,
   type SinkConfig,
@@ -41,7 +42,7 @@ export interface SinkCommandOptions {
   pathStyle?: boolean;
   teamId?: string;
   userId?: string;
-  yes?: boolean;
+  restart?: boolean;
 }
 
 export interface SinkCandidateInput extends SinkCommandOptions {
@@ -52,8 +53,9 @@ export async function sinkAddCommand(
   type: SinkType,
   opts: SinkCommandOptions,
 ): Promise<void> {
+  await preflightSinkCandidate({ ...opts, type });
   const { result } = await updateConfig(
-    (config) => ensureSinkConfigured(config, { ...opts, type }),
+    (config) => ensureSinkConfigured(config, { ...opts, type }, { validate: false }),
     {
       shouldSave: (result) => result.created,
     },
@@ -65,7 +67,7 @@ export async function sinkAddCommand(
   }
 
   await finalizeConfigChange({
-    yes: opts.yes,
+    restart: opts.restart,
     changeSummary: `Added sink ${result.sinkId}`,
   });
   console.log(
@@ -75,7 +77,7 @@ export async function sinkAddCommand(
 
 export async function sinkRemoveCommand(
   sinkId: string,
-  opts: { yes?: boolean } = {},
+  opts: { restart?: boolean } = {},
 ): Promise<void> {
   if (!sinkId) {
     fail("specify a sink id");
@@ -108,7 +110,7 @@ export async function sinkRemoveCommand(
   });
 
   await finalizeConfigChange({
-    yes: opts.yes,
+    restart: opts.restart,
     changeSummary:
       result.affectedRoutes > 0
         ? `Removed sink ${sinkId} and updated ${result.affectedRoutes} route${result.affectedRoutes === 1 ? "" : "s"}`
@@ -118,14 +120,14 @@ export async function sinkRemoveCommand(
 
 export async function sinkDisableCommand(
   sinkId: string,
-  opts: { yes?: boolean } = {},
+  opts: { restart?: boolean } = {},
 ): Promise<void> {
   await setSinkEnabled(sinkId, false, opts);
 }
 
 export async function sinkEnableCommand(
   sinkId: string,
-  opts: { yes?: boolean } = {},
+  opts: { restart?: boolean } = {},
 ): Promise<void> {
   await setSinkEnabled(sinkId, true, opts);
 }
@@ -239,6 +241,7 @@ export async function sinkRepushCommand(sinkId: string): Promise<void> {
 export async function ensureSinkConfigured(
   config: JinConfig,
   input: SinkCandidateInput,
+  opts: { validate?: boolean } = {},
 ): Promise<{ sinkId: string; created: boolean; sink: SinkConfig }> {
   const candidate = buildSinkConfig(config, input);
 
@@ -261,9 +264,39 @@ export async function ensureSinkConfigured(
     );
   }
 
-  await validateSink(candidate, config.sinks.length);
+  if (opts.validate !== false) {
+    await validateSink(candidate, config.sinks.length);
+  }
   config.sinks.push(candidate);
   return { sinkId: candidate.id, created: true, sink: candidate };
+}
+
+export async function preflightSinkCandidate(
+  input: SinkCandidateInput,
+): Promise<void> {
+  const config = await loadRuntimeConfigGeneration();
+  const candidate = buildSinkConfig(config, input);
+
+  const existingById = findSinkIndexById(config, candidate.id);
+  if (existingById >= 0) {
+    const existing = config.sinks[existingById];
+    if (sameSinkIdentity(existing, candidate)) {
+      return;
+    }
+    fail(`sink id "${candidate.id}" is already configured`);
+  }
+
+  const equivalent = config.sinks.find((sink) => sameSinkTransport(sink, candidate));
+  if (equivalent) {
+    if (sameSinkIdentity(equivalent, candidate)) {
+      return;
+    }
+    fail(
+      `sink transport is already configured as "${equivalent.id}" with different teamId/userId; duplicate transport endpoints with different export identity are not supported yet`,
+    );
+  }
+
+  await validateSink(candidate, config.sinks.length);
 }
 
 export function findSinkIndexById(config: Pick<JinConfig, "sinks">, sinkId: string): number {
@@ -387,7 +420,7 @@ async function validateSink(sinkConfig: SinkConfig, index: number): Promise<void
 async function setSinkEnabled(
   sinkId: string,
   enabled: boolean,
-  opts: { yes?: boolean } = {},
+  opts: { restart?: boolean } = {},
 ): Promise<void> {
   if (!sinkId) {
     fail("specify a sink id");
@@ -433,10 +466,10 @@ async function setSinkEnabled(
 async function persistSinkControlChange(
   sinkId: string,
   enabled: boolean,
-  opts: { yes?: boolean },
+  opts: { restart?: boolean },
 ): Promise<void> {
   await finalizeConfigChange({
-    yes: opts.yes,
+    restart: opts.restart,
     changeSummary: `Sink ${sinkId} ${enabled ? "enabled" : "disabled"}`,
   });
 }

--- a/src/commands/sink.ts
+++ b/src/commands/sink.ts
@@ -435,7 +435,7 @@ async function persistSinkControlChange(
   }
 
   if (runtimeUpdated) {
-    console.log("  Updated the active runtime without a full restart.");
+    console.log("  Active runtime status updated; config reload will apply shortly.");
   } else {
     console.log("  Change saved; it will apply on the next start.");
   }

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -2,7 +2,7 @@ import {
   configDir,
   configPath,
   discoveryCachePath,
-  loadConfig,
+  loadRuntimeConfigGeneration,
   loadStartupConfig,
   resolveAdapterConfig,
   type JinConfig,
@@ -10,6 +10,7 @@ import {
 import type { Adapter as V2Adapter } from "../contracts/adapters";
 import type { Sink as V2Sink } from "../contracts/sinks";
 import { allAdapters, protectedSourceStartupNotices, startupProbeBlocked } from "../adapters/registry";
+import { createLocalControlBoundary } from "../api/control";
 import { startLocalApiServer, type LocalApiServer } from "../api/server";
 import { SqliteDiscoveryCache } from "../db/discovery-cache";
 import { openStoreAtPath, type SqliteConversationStore } from "../db/store";
@@ -140,6 +141,9 @@ export async function watchCommand(opts: { daemon?: boolean }): Promise<void> {
   try {
     apiServer = startLocalApiServer({
       queryStore: store,
+      controlBoundary: createLocalControlBoundary({
+        requestConfigReload: () => pipelineHandle.reloadConfig("command"),
+      }),
       socketPath: runtimePaths.socketPath,
     });
   } catch (error) {
@@ -187,6 +191,7 @@ async function startPipeline(
       getSinks: () => currentSinks,
       getRoutes: () => currentConfig.routes,
       getScanIntervalMs: () => currentConfig.watch.pollIntervalMs,
+      shouldContinueSinkPush: (sinkId) => diskConfigAllowsSinkPush(sinkId, log),
       scanIntervalMs: currentConfig.watch.pollIntervalMs,
       watchDebounceMs: currentConfig.watch.debounceMs,
       // Runtime push batches stay tiny so the live Codex workload can drain
@@ -202,11 +207,12 @@ async function startPipeline(
           log,
         });
         if (!next) {
-          return;
+          return false;
         }
 
         currentConfig = next.config;
         currentSinks = next.sinks;
+        return true;
       },
       workerIngest: {
         command: resolveSelfCommand(),
@@ -510,7 +516,7 @@ async function reloadRuntimeConfig(
   },
 ): Promise<{ config: JinConfig; sinks: V2Sink[] } | null> {
   try {
-    const nextConfig = await loadConfig();
+    const nextConfig = await loadRuntimeConfigGeneration();
     if (JSON.stringify(nextConfig) === JSON.stringify(currentConfig)) {
       options.log("Config file changed, but the runtime view is unchanged.");
       return {
@@ -535,6 +541,22 @@ async function reloadRuntimeConfig(
     options.log(`ERROR: Config reload failed; stopping runtime. ${formatError(error)}`);
     requestSelfShutdown();
     return null;
+  }
+}
+
+async function diskConfigAllowsSinkPush(
+  sinkId: string,
+  log: RuntimeLog,
+): Promise<boolean> {
+  try {
+    const nextConfig = await loadRuntimeConfigGeneration();
+    const sinkConfig = nextConfig.sinks.find((sink) => sink.id === sinkId);
+    return sinkConfig?.enabled !== false;
+  } catch (error) {
+    log(
+      `WARNING: Stopping push while current config cannot be validated: ${formatError(error)}`,
+    );
+    return false;
   }
 }
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -3,6 +3,7 @@ import {
   configPath,
   discoveryCachePath,
   loadRuntimeConfigGeneration,
+  loadRuntimeConfigSnapshot,
   loadStartupConfig,
   resolveAdapterConfig,
   type JinConfig,
@@ -17,6 +18,7 @@ import { openStoreAtPath, type SqliteConversationStore } from "../db/store";
 import { daemonize } from "../daemon/daemonize";
 import { appendDiagnosticEvent } from "../pipeline/diagnostic";
 import { runPipeline } from "../pipeline/loop";
+import type { PushDeliverySnapshot } from "../pipeline/push";
 import type { PipelineHandle, PipelineLogger } from "../pipeline/types";
 import { createSink } from "../sinks/registry";
 import {
@@ -191,7 +193,7 @@ async function startPipeline(
       getSinks: () => currentSinks,
       getRoutes: () => currentConfig.routes,
       getScanIntervalMs: () => currentConfig.watch.pollIntervalMs,
-      shouldContinueSinkPush: (sinkId) => diskConfigAllowsSinkPush(sinkId, log),
+      getCurrentDeliverySnapshot: () => loadPushDeliverySnapshot(),
       scanIntervalMs: currentConfig.watch.pollIntervalMs,
       watchDebounceMs: currentConfig.watch.debounceMs,
       // Runtime push batches stay tiny so the live Codex workload can drain
@@ -544,20 +546,16 @@ async function reloadRuntimeConfig(
   }
 }
 
-async function diskConfigAllowsSinkPush(
-  sinkId: string,
-  log: RuntimeLog,
-): Promise<boolean> {
-  try {
-    const nextConfig = await loadRuntimeConfigGeneration();
-    const sinkConfig = nextConfig.sinks.find((sink) => sink.id === sinkId);
-    return sinkConfig?.enabled !== false;
-  } catch (error) {
-    log(
-      `WARNING: Stopping push while current config cannot be validated: ${formatError(error)}`,
-    );
-    return false;
-  }
+async function loadPushDeliverySnapshot(): Promise<PushDeliverySnapshot> {
+  const snapshot = await loadRuntimeConfigSnapshot();
+  return {
+    generationToken: snapshot.generationToken,
+    sinks: snapshot.config.sinks.map((sink) => ({
+      id: sink.id,
+      enabled: sink.enabled,
+    })),
+    routes: snapshot.config.routes,
+  };
 }
 
 function requestSelfShutdown(): void {

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -2,6 +2,7 @@ import {
   configDir,
   configPath,
   discoveryCachePath,
+  loadConfig,
   loadStartupConfig,
   resolveAdapterConfig,
   type JinConfig,
@@ -17,11 +18,20 @@ import { appendDiagnosticEvent } from "../pipeline/diagnostic";
 import { runPipeline } from "../pipeline/loop";
 import type { PipelineHandle, PipelineLogger } from "../pipeline/types";
 import { createSink } from "../sinks/registry";
-import { appendFileSync, existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
-import { join } from "path";
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  unlinkSync,
+  watch,
+  writeFileSync,
+  type FSWatcher,
+} from "fs";
+import { basename, join } from "path";
 import { resolveSelfCommand } from "../runtime/self-command";
 
 type RuntimeLog = (message: string) => void;
+const CONFIG_RELOAD_WATCH_DEBOUNCE_MS = 150;
 
 export async function watchCommand(opts: { daemon?: boolean }): Promise<void> {
   const {
@@ -158,6 +168,8 @@ async function startPipeline(
   initialAdapters: V2Adapter[],
   diagnosticPath: string,
 ): Promise<PipelineHandle> {
+  let currentConfig = config;
+  let currentSinks = sinks;
   let useInitialAdapters = true;
 
   try {
@@ -167,13 +179,16 @@ async function startPipeline(
           useInitialAdapters = false;
           return initialAdapters;
         }
-        return detectActiveAdapters(config, diagnosticPath);
+        return detectActiveAdapters(currentConfig, diagnosticPath);
       },
       store,
-      sinks,
-      routes: config.routes,
-      scanIntervalMs: config.watch.pollIntervalMs,
-      watchDebounceMs: config.watch.debounceMs,
+      sinks: currentSinks,
+      routes: currentConfig.routes,
+      getSinks: () => currentSinks,
+      getRoutes: () => currentConfig.routes,
+      getScanIntervalMs: () => currentConfig.watch.pollIntervalMs,
+      scanIntervalMs: currentConfig.watch.pollIntervalMs,
+      watchDebounceMs: currentConfig.watch.debounceMs,
       // Runtime push batches stay tiny so the live Codex workload can drain
       // store->sink work without pinning a full multi-conversation batch.
       pushBatchSize: 2,
@@ -181,19 +196,36 @@ async function startPipeline(
       deferWatcherStart: true,
       logger: toPipelineLogger(log),
       diagnosticLogPath: diagnosticPath,
+      onConfigReload: async (source) => {
+        const next = await reloadRuntimeConfig(currentConfig, currentSinks, {
+          source,
+          log,
+        });
+        if (!next) {
+          return;
+        }
+
+        currentConfig = next.config;
+        currentSinks = next.sinks;
+      },
       workerIngest: {
         command: resolveSelfCommand(),
-        adapterConfigs: config.adapters,
+        adapterConfigs: currentConfig.adapters,
+        getAdapterConfigs: () => currentConfig.adapters,
       },
       ...(discoveryCache
         ? {
             discoveryCache: {
               store: discoveryCache,
-              adapterConfigs: config.adapters,
+              adapterConfigs: currentConfig.adapters,
+              getAdapterConfigs: () => currentConfig.adapters,
             },
           }
         : {}),
     });
+    const configWatcher = watchConfigFile(() => {
+      handle.reloadConfig("config-file");
+    }, log);
     for (const adapter of initialAdapters) {
       handle.enqueue({
         kind: "ingest-adapter",
@@ -201,7 +233,15 @@ async function startPipeline(
         hint: { kind: "startup-scan" },
       });
     }
-    return handle;
+    return {
+      enqueue: handle.enqueue,
+      reloadConfig: handle.reloadConfig,
+      waitForIdle: handle.waitForIdle,
+      shutdown: async () => {
+        configWatcher.close();
+        return handle.shutdown();
+      },
+    };
   } catch (error) {
     await closeSinks(sinks);
     store.close();
@@ -457,8 +497,95 @@ function logProtectedSourceStartupNotices(
     log(notice.summary);
   }
   log(
-    `Opt in via ${configPath()}: set adapters.<id>.allowProtectedSource = true or adapters.<id>.dataDir to a user-provided path, then restart with \`jin stop\` and \`jin start\`.`,
+    `Opt in via ${configPath()}: set adapters.<id>.allowProtectedSource = true or adapters.<id>.dataDir to a user-provided path, then save the file. A running runtime will reload it shortly; otherwise restart with \`jin stop\` and \`jin start\`.`,
   );
+}
+
+async function reloadRuntimeConfig(
+  currentConfig: JinConfig,
+  currentSinks: ReadonlyArray<V2Sink>,
+  options: {
+    source: "config-file" | "command";
+    log: RuntimeLog;
+  },
+): Promise<{ config: JinConfig; sinks: V2Sink[] } | null> {
+  try {
+    const nextConfig = await loadConfig();
+    if (JSON.stringify(nextConfig) === JSON.stringify(currentConfig)) {
+      options.log("Config file changed, but the runtime view is unchanged.");
+      return {
+        config: currentConfig,
+        sinks: [...currentSinks],
+      };
+    }
+
+    const nextSinks = await createActiveSinks(nextConfig, options.log);
+    await closeSinks(currentSinks);
+
+    options.log(
+      `Reloaded config from ${
+        options.source === "command" ? "control event" : "config file"
+      }: ${nextConfig.routes.length} route(s), ${nextSinks.length} sink(s).`,
+    );
+    return {
+      config: nextConfig,
+      sinks: nextSinks,
+    };
+  } catch (error) {
+    options.log(`ERROR: Config reload failed; stopping runtime. ${formatError(error)}`);
+    requestSelfShutdown();
+    return null;
+  }
+}
+
+function requestSelfShutdown(): void {
+  setTimeout(() => {
+    try {
+      process.kill(process.pid, "SIGTERM");
+    } catch {
+      process.exit(1);
+    }
+  }, 0);
+}
+
+function watchConfigFile(
+  onChange: () => void,
+  log: RuntimeLog,
+): { close(): void } {
+  let watcher: FSWatcher | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  const watchedFilename = basename(configPath());
+
+  try {
+    watcher = watch(configDir(), (_eventType, filename) => {
+      const reportedFilename = filename?.toString();
+      if (reportedFilename && reportedFilename !== watchedFilename) {
+        return;
+      }
+
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+      }
+
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        onChange();
+      }, CONFIG_RELOAD_WATCH_DEBOUNCE_MS);
+    });
+  } catch (error) {
+    log(`WARNING: Config file watcher is unavailable; config changes will apply on restart only. ${formatError(error)}`);
+  }
+
+  return {
+    close() {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      watcher?.close();
+      watcher = null;
+    },
+  };
 }
 
 async function closeSinks(sinks: ReadonlyArray<V2Sink>): Promise<void> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ import {
   unlinkSync,
   writeFileSync,
 } from "fs";
+import { createHash } from "node:crypto";
 import { homedir } from "os";
 import { join } from "path";
 import {
@@ -135,6 +136,11 @@ export interface JinConfig extends Omit<ContractJinConfig, "sinks" | "routes" | 
   store?: StoreConfig;
 }
 
+export interface RuntimeConfigSnapshot {
+  config: JinConfig;
+  generationToken: string;
+}
+
 const DEFAULT_ADAPTER_IDS = [
   "claude-code",
   "cursor",
@@ -250,16 +256,27 @@ export async function loadConfig(): Promise<JinConfig> {
 }
 
 export async function loadRuntimeConfigGeneration(): Promise<JinConfig> {
+  return (await loadRuntimeConfigSnapshot()).config;
+}
+
+export async function loadRuntimeConfigSnapshot(): Promise<RuntimeConfigSnapshot> {
   ensureConfigDir();
   const cfgPath = configPath();
   if (!existsSync(cfgPath)) {
-    return defaultConfig();
+    const config = defaultConfig();
+    return {
+      config,
+      generationToken: hashConfigGeneration(JSON.stringify(config)),
+    };
   }
 
   const rawText = await Bun.file(cfgPath).text();
   const raw = JSON.parse(rawText);
   assertValidRuntimeConfigGeneration(raw);
-  return normalizeConfig(raw);
+  return {
+    config: normalizeConfig(raw),
+    generationToken: hashConfigGeneration(rawText),
+  };
 }
 
 export async function loadStartupConfig(): Promise<JinConfig> {
@@ -458,6 +475,10 @@ function isPermissionError(error: unknown): boolean {
     "code" in error &&
     (error as { code?: unknown }).code === "EPERM"
   );
+}
+
+function hashConfigGeneration(rawText: string): string {
+  return createHash("sha256").update(rawText).digest("hex");
 }
 
 function defaultAdapters(): Record<string, AdapterConfig> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,14 @@
-import { existsSync, mkdirSync } from "fs";
+import {
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
 import { homedir } from "os";
 import { join } from "path";
 import {
@@ -51,6 +61,10 @@ const PROTECTED_SOURCE_ADAPTER_IDS = [
 const PROTECTED_SOURCE_ADAPTER_ID_SET = new Set<string>(
   PROTECTED_SOURCE_ADAPTER_IDS,
 );
+const CONFIG_LOCK_FILENAME = "config.lock";
+const CONFIG_WRITE_TIMEOUT_MS = 5_000;
+const CONFIG_LOCK_STALE_MS = 30_000;
+const CONFIG_LOCK_POLL_MS = 50;
 
 export interface AdapterConfig extends ContractAdapterConfig {
   allowProtectedSource?: boolean;
@@ -184,6 +198,10 @@ export function configPath(): string {
   return join(configDir(), "config.json");
 }
 
+export function configLockPath(): string {
+  return join(configDir(), CONFIG_LOCK_FILENAME);
+}
+
 export function discoveryCachePath(): string {
   return join(configDir(), "discovery-cache.db");
 }
@@ -232,27 +250,200 @@ export async function loadConfig(): Promise<JinConfig> {
 }
 
 export async function loadStartupConfig(): Promise<JinConfig> {
-  ensureConfigDir();
-  const cfgPath = configPath();
-  if (!existsSync(cfgPath)) {
-    const config = defaultConfig();
-    await saveConfig(config);
-    return config;
-  }
+  return withConfigLock(async () => {
+    ensureConfigDir();
+    const cfgPath = configPath();
+    if (!existsSync(cfgPath)) {
+      const config = defaultConfig();
+      await writeConfigFile(config, { normalize: false });
+      return config;
+    }
 
-  const rawText = await Bun.file(cfgPath).text();
-  const raw = JSON.parse(rawText);
-  const materialized = materializeConfigShape(raw);
-  if (materialized.changed) {
-    await Bun.write(cfgPath, JSON.stringify(materialized.value, null, 2));
-  }
+    const rawText = await Bun.file(cfgPath).text();
+    const raw = JSON.parse(rawText);
+    const materialized = materializeConfigShape(raw);
+    if (materialized.changed) {
+      await writeConfigFile(materialized.value, { normalize: false });
+    }
 
-  return normalizeConfig(materialized.value);
+    return normalizeConfig(materialized.value);
+  });
 }
 
 export async function saveConfig(config: JinConfig): Promise<void> {
+  await withConfigLock(async () => {
+    await writeConfigFile(config);
+  });
+}
+
+export async function updateConfig<T>(
+  mutate: (config: JinConfig) => Promise<T> | T,
+  opts: {
+    shouldSave?: (result: T, config: JinConfig) => boolean;
+  } = {},
+): Promise<{ config: JinConfig; result: T; saved: boolean }> {
+  return withConfigLock(async () => {
+    const config = await loadConfig();
+    const result = await mutate(config);
+    const shouldSave = opts.shouldSave?.(result, config) ?? true;
+    if (shouldSave) {
+      await writeConfigFile(config);
+    }
+
+    return {
+      config: normalizeConfig(config),
+      result,
+      saved: shouldSave,
+    };
+  });
+}
+
+async function writeConfigFile(
+  config: unknown,
+  opts: { normalize?: boolean } = {},
+): Promise<void> {
   ensureConfigDir();
-  await Bun.write(configPath(), JSON.stringify(normalizeConfig(config), null, 2));
+  const cfgPath = configPath();
+  const tmpPath = `${cfgPath}.${process.pid}.${Date.now()}.${Math.random()
+    .toString(16)
+    .slice(2)}.tmp`;
+  const value = opts.normalize === false ? config : normalizeConfig(config);
+  const serialized = JSON.stringify(value, null, 2);
+
+  try {
+    await Bun.write(tmpPath, serialized);
+    renameSync(tmpPath, cfgPath);
+  } catch (error) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {}
+    throw error;
+  }
+}
+
+async function withConfigLock<T>(fn: () => Promise<T>): Promise<T> {
+  ensureConfigDir();
+  const release = await acquireConfigLock();
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+async function acquireConfigLock(
+  timeoutMs = CONFIG_WRITE_TIMEOUT_MS,
+): Promise<() => void> {
+  const lockPath = configLockPath();
+  const deadline = Date.now() + Math.max(timeoutMs, CONFIG_LOCK_POLL_MS);
+  const token = `${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2)}`;
+
+  while (true) {
+    try {
+      const fd = openSync(lockPath, "wx");
+      try {
+        writeFileSync(
+          fd,
+          JSON.stringify({
+            pid: process.pid,
+            acquiredAt: new Date().toISOString(),
+            token,
+          }),
+        );
+      } finally {
+        closeSync(fd);
+      }
+
+      return () => releaseConfigLock(lockPath, token);
+    } catch (error) {
+      if (!isFileExistsError(error)) {
+        throw error;
+      }
+
+      clearStaleConfigLock(lockPath);
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for config lock at ${lockPath}`);
+      }
+
+      await Bun.sleep(CONFIG_LOCK_POLL_MS);
+    }
+  }
+}
+
+function releaseConfigLock(lockPath: string, token: string): void {
+  try {
+    const raw = readFileSync(lockPath, "utf-8");
+    const parsed = JSON.parse(raw) as { token?: unknown };
+    if (parsed.token !== token) {
+      return;
+    }
+    unlinkSync(lockPath);
+  } catch {}
+}
+
+function clearStaleConfigLock(lockPath: string): void {
+  let pid: number | undefined;
+  let ageMs = Number.POSITIVE_INFINITY;
+
+  try {
+    const raw = readFileSync(lockPath, "utf-8");
+    const parsed = JSON.parse(raw) as { pid?: unknown; acquiredAt?: unknown };
+    if (typeof parsed.pid === "number" && Number.isFinite(parsed.pid)) {
+      pid = parsed.pid;
+    }
+    if (typeof parsed.acquiredAt === "string") {
+      const acquiredMs = Date.parse(parsed.acquiredAt);
+      if (Number.isFinite(acquiredMs)) {
+        ageMs = Date.now() - acquiredMs;
+      }
+    }
+  } catch {}
+
+  if (!Number.isFinite(ageMs)) {
+    try {
+      ageMs = Date.now() - statSync(lockPath).mtimeMs;
+    } catch {
+      ageMs = Number.POSITIVE_INFINITY;
+    }
+  }
+
+  if (pid !== undefined && isProcessAlive(pid)) {
+    return;
+  }
+  if (ageMs < CONFIG_LOCK_STALE_MS) {
+    return;
+  }
+
+  try {
+    unlinkSync(lockPath);
+  } catch {}
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return isPermissionError(error);
+  }
+}
+
+function isFileExistsError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "EEXIST"
+  );
+}
+
+function isPermissionError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "EPERM"
+  );
 }
 
 function defaultAdapters(): Record<string, AdapterConfig> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -249,6 +249,19 @@ export async function loadConfig(): Promise<JinConfig> {
   return normalizeConfig(JSON.parse(raw));
 }
 
+export async function loadRuntimeConfigGeneration(): Promise<JinConfig> {
+  ensureConfigDir();
+  const cfgPath = configPath();
+  if (!existsSync(cfgPath)) {
+    return defaultConfig();
+  }
+
+  const rawText = await Bun.file(cfgPath).text();
+  const raw = JSON.parse(rawText);
+  assertValidRuntimeConfigGeneration(raw);
+  return normalizeConfig(raw);
+}
+
 export async function loadStartupConfig(): Promise<JinConfig> {
   return withConfigLock(async () => {
     ensureConfigDir();
@@ -262,6 +275,7 @@ export async function loadStartupConfig(): Promise<JinConfig> {
     const rawText = await Bun.file(cfgPath).text();
     const raw = JSON.parse(rawText);
     const materialized = materializeConfigShape(raw);
+    assertValidRuntimeConfigGeneration(materialized.value);
     if (materialized.changed) {
       await writeConfigFile(materialized.value, { normalize: false });
     }
@@ -283,7 +297,7 @@ export async function updateConfig<T>(
   } = {},
 ): Promise<{ config: JinConfig; result: T; saved: boolean }> {
   return withConfigLock(async () => {
-    const config = await loadConfig();
+    const config = await loadRuntimeConfigGeneration();
     const result = await mutate(config);
     const shouldSave = opts.shouldSave?.(result, config) ?? true;
     if (shouldSave) {
@@ -616,6 +630,183 @@ function normalizeSinkConfig(raw: unknown): SinkConfig | null {
   }
 }
 
+function assertValidRuntimeConfigGeneration(raw: unknown): void {
+  if (!isRecord(raw)) {
+    throw new Error("config root must be an object");
+  }
+
+  assertValidAdaptersSection(raw.adapters);
+  assertValidSinksSection(raw.sinks);
+  assertValidRoutesSection(raw.routes);
+  assertValidWatchSection(raw.watch);
+}
+
+function assertValidAdaptersSection(raw: unknown): void {
+  if (raw === undefined) {
+    return;
+  }
+  if (!isRecord(raw)) {
+    throw new Error("config.adapters must be an object");
+  }
+
+  for (const [adapterId, value] of Object.entries(raw)) {
+    if (!isRecord(value)) {
+      throw new Error(`config.adapters.${adapterId} must be an object`);
+    }
+    if ("enabled" in value && typeof value.enabled !== "boolean") {
+      throw new Error(`config.adapters.${adapterId}.enabled must be a boolean`);
+    }
+    if (
+      "allowProtectedSource" in value &&
+      typeof value.allowProtectedSource !== "boolean"
+    ) {
+      throw new Error(
+        `config.adapters.${adapterId}.allowProtectedSource must be a boolean`,
+      );
+    }
+    if ("dataDir" in value && asNonEmptyString(value.dataDir) === undefined) {
+      throw new Error(`config.adapters.${adapterId}.dataDir must be a non-empty string`);
+    }
+  }
+}
+
+function assertValidSinksSection(raw: unknown): void {
+  if (raw === undefined) {
+    return;
+  }
+  if (!Array.isArray(raw)) {
+    throw new Error("config.sinks must be an array");
+  }
+
+  raw.forEach((value, index) => assertValidSinkConfig(value, index));
+}
+
+function assertValidSinkConfig(raw: unknown, index: number): void {
+  const path = `config.sinks[${index}]`;
+  if (!isRecord(raw)) {
+    throw new Error(`${path} must be an object`);
+  }
+
+  const id = asNonEmptyString(raw.id);
+  if (!id) {
+    throw new Error(`${path}.id must be a non-empty string`);
+  }
+
+  const type = asSinkType(raw.type);
+  if (!type) {
+    throw new Error(`${path}.type must be one of ${SINK_TYPES.join(", ")}`);
+  }
+
+  assertOptionalBoolean(raw.enabled, `${path}.enabled`);
+  assertOptionalNonEmptyString(raw.teamId, `${path}.teamId`);
+  assertOptionalNonEmptyString(raw.userId, `${path}.userId`);
+
+  switch (type) {
+    case "postgres":
+      assertRequiredNonEmptyString(raw.connectionString, `${path}.connectionString`);
+      return;
+    case "s3":
+      assertRequiredNonEmptyString(raw.bucket, `${path}.bucket`);
+      assertRequiredNonEmptyString(raw.accessKeyId, `${path}.accessKeyId`);
+      assertRequiredNonEmptyString(raw.secretAccessKey, `${path}.secretAccessKey`);
+      assertOptionalNonEmptyString(raw.region, `${path}.region`);
+      assertOptionalNonEmptyString(raw.endpoint, `${path}.endpoint`);
+      assertOptionalNonEmptyString(raw.prefix, `${path}.prefix`);
+      assertOptionalBoolean(raw.pathStyle, `${path}.pathStyle`);
+      return;
+    case "webhook":
+      assertRequiredNonEmptyString(raw.url, `${path}.url`);
+      assertOptionalPositiveInteger(raw.timeoutMs, `${path}.timeoutMs`);
+      assertOptionalStringRecord(raw.headers, `${path}.headers`);
+      return;
+  }
+}
+
+function assertValidRoutesSection(raw: unknown): void {
+  if (raw === undefined) {
+    return;
+  }
+  if (!Array.isArray(raw)) {
+    throw new Error("config.routes must be an array");
+  }
+
+  raw.forEach((value, index) => {
+    const path = `config.routes[${index}]`;
+    if (!isRecord(value)) {
+      throw new Error(`${path} must be an object`);
+    }
+    if (!isRecord(value.match)) {
+      throw new Error(`${path}.match must be an object`);
+    }
+    for (const key of ["remote", "adapter", "branch", "name"] as const) {
+      assertOptionalString(value.match[key], `${path}.match.${key}`);
+    }
+    if (!Array.isArray(value.sinks)) {
+      throw new Error(`${path}.sinks must be an array`);
+    }
+    value.sinks.forEach((sinkId, sinkIndex) => {
+      if (asNonEmptyString(sinkId) === undefined) {
+        throw new Error(`${path}.sinks[${sinkIndex}] must be a non-empty string`);
+      }
+    });
+  });
+}
+
+function assertValidWatchSection(raw: unknown): void {
+  if (raw === undefined) {
+    return;
+  }
+  if (!isRecord(raw)) {
+    throw new Error("config.watch must be an object");
+  }
+  assertOptionalPositiveInteger(raw.pollIntervalMs, "config.watch.pollIntervalMs");
+  assertOptionalPositiveInteger(raw.debounceMs, "config.watch.debounceMs");
+}
+
+function assertRequiredNonEmptyString(value: unknown, path: string): void {
+  if (asNonEmptyString(value) === undefined) {
+    throw new Error(`${path} must be a non-empty string`);
+  }
+}
+
+function assertOptionalNonEmptyString(value: unknown, path: string): void {
+  if (value !== undefined) {
+    assertRequiredNonEmptyString(value, path);
+  }
+}
+
+function assertOptionalString(value: unknown, path: string): void {
+  if (value !== undefined && typeof value !== "string") {
+    throw new Error(`${path} must be a string`);
+  }
+}
+
+function assertOptionalBoolean(value: unknown, path: string): void {
+  if (value !== undefined && typeof value !== "boolean") {
+    throw new Error(`${path} must be a boolean`);
+  }
+}
+
+function assertOptionalPositiveInteger(value: unknown, path: string): void {
+  if (value !== undefined && asPositiveInteger(value) === undefined) {
+    throw new Error(`${path} must be a positive integer`);
+  }
+}
+
+function assertOptionalStringRecord(value: unknown, path: string): void {
+  if (value === undefined) {
+    return;
+  }
+  if (!isRecord(value)) {
+    throw new Error(`${path} must be an object`);
+  }
+  for (const [key, entryValue] of Object.entries(value)) {
+    if (typeof entryValue !== "string") {
+      throw new Error(`${path}.${key} must be a string`);
+    }
+  }
+}
+
 function normalizeRoutes(raw: unknown): RouteConfig[] {
   if (!Array.isArray(raw)) {
     return [];
@@ -686,57 +877,74 @@ function resolveSinkUserId(raw: Record<string, unknown>): string | undefined {
 }
 
 function materializeConfigShape(raw: unknown): {
-  value: JinConfig | Record<string, unknown>;
+  value: unknown;
   changed: boolean;
 } {
   const base = defaultConfig();
   if (!isRecord(raw)) {
-    return { value: base, changed: true };
+    return { value: raw, changed: false };
   }
 
   const next: Record<string, unknown> = structuredClone(raw);
   let changed = false;
 
-  const materializedAdapters = materializeAdaptersSection(next.adapters, base.adapters);
-  if (materializedAdapters.changed) {
-    next.adapters = materializedAdapters.value;
+  if (next.adapters === undefined) {
+    next.adapters = structuredClone(base.adapters);
     changed = true;
+  } else if (isRecord(next.adapters)) {
+    const materializedAdapters = materializeAdaptersSection(
+      next.adapters,
+      base.adapters,
+    );
+    if (materializedAdapters.changed) {
+      next.adapters = materializedAdapters.value;
+      changed = true;
+    }
   }
 
-  if (!Array.isArray(next.sinks)) {
+  if (next.sinks === undefined) {
     next.sinks = [];
     changed = true;
   }
 
-  if (!Array.isArray(next.routes)) {
+  if (next.routes === undefined) {
     next.routes = [];
     changed = true;
   }
 
-  const materializedWatch = materializeWatchSection(next.watch, base.watch);
-  if (materializedWatch.changed) {
-    next.watch = materializedWatch.value;
+  if (next.watch === undefined) {
+    next.watch = { ...base.watch };
     changed = true;
+  } else if (isRecord(next.watch)) {
+    const materializedWatch = materializeWatchSection(next.watch, base.watch);
+    if (materializedWatch.changed) {
+      next.watch = materializedWatch.value;
+      changed = true;
+    }
   }
 
   return { value: next, changed };
 }
 
 function materializeAdaptersSection(
-  raw: unknown,
+  raw: Record<string, unknown>,
   fallback: Record<string, AdapterConfig>,
 ): {
   value: Record<string, unknown>;
   changed: boolean;
 } {
-  const next = isRecord(raw) ? structuredClone(raw) : {};
-  let changed = !isRecord(raw);
+  const next = structuredClone(raw);
+  let changed = false;
 
   for (const [adapterId, defaultAdapter] of Object.entries(fallback)) {
     const existing = next[adapterId];
-    if (!isRecord(existing)) {
+    if (existing === undefined) {
       next[adapterId] = { ...defaultAdapter };
       changed = true;
+      continue;
+    }
+
+    if (!isRecord(existing)) {
       continue;
     }
 
@@ -751,23 +959,16 @@ function materializeAdaptersSection(
 }
 
 function materializeWatchSection(
-  raw: unknown,
+  raw: Record<string, unknown>,
   fallback: WatchConfig,
 ): {
   value: Record<string, unknown>;
   changed: boolean;
 } {
-  if (!isRecord(raw)) {
-    return {
-      value: { ...fallback },
-      changed: true,
-    };
-  }
-
   const next = structuredClone(raw);
   let changed = false;
 
-  if (asPositiveInteger(next.pollIntervalMs) === undefined) {
+  if (next.pollIntervalMs === undefined) {
     next.pollIntervalMs = fallback.pollIntervalMs;
     changed = true;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,8 +237,8 @@ const COMMAND_HELP: Record<string, string> = {
   USAGE
     jin sink add <type> [flags]
     jin sink remove <id> [--yes]
-    jin sink disable <id>
-    jin sink enable <id>
+    jin sink disable <id> [--yes]
+    jin sink enable <id> [--yes]
     jin sink repush <id>
 
   EXAMPLES
@@ -251,8 +251,8 @@ const COMMAND_HELP: Record<string, string> = {
   Manage low-level routing rules for local conversations
 
   USAGE
-    jin route add --sink=<id> [--remote=<glob>] [--adapter=<id>] [--branch=<glob>] [--name=<glob>]
-    jin route remove [--sink=<id>] [--remote=<glob>] [--adapter=<id>] [--branch=<glob>] [--name=<glob>]
+    jin route add --sink=<id> [--remote=<glob>] [--adapter=<id>] [--branch=<glob>] [--name=<glob>] [--yes]
+    jin route remove [--sink=<id>] [--remote=<glob>] [--adapter=<id>] [--branch=<glob>] [--name=<glob>] [--yes]
 
   EXAMPLES
     $ jin route add --remote="github.com/acme/*" --sink=team-postgres
@@ -535,17 +535,17 @@ async function main(): Promise<void> {
           break;
         case "disable":
           if (!sinkId || sinkId.startsWith("--")) {
-            console.error("Usage: jin sink disable <sink-id>");
+            console.error("Usage: jin sink disable <sink-id> [--yes]");
             process.exit(1);
           }
-          await sinkDisableCommand(sinkId);
+          await sinkDisableCommand(sinkId, { yes: !!flags.yes });
           break;
         case "enable":
           if (!sinkId || sinkId.startsWith("--")) {
-            console.error("Usage: jin sink enable <sink-id>");
+            console.error("Usage: jin sink enable <sink-id> [--yes]");
             process.exit(1);
           }
-          await sinkEnableCommand(sinkId);
+          await sinkEnableCommand(sinkId, { yes: !!flags.yes });
           break;
         case "repush":
           if (!sinkId || sinkId.startsWith("--")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,10 @@ function parseBooleanFlag(value: string | boolean | undefined): boolean | undefi
 
 const flags = parseFlags(args.slice(1));
 
+function readConfigRestartFlag(): boolean {
+  return !!flags.restart;
+}
+
 const COMMAND_HELP: Record<string, string> = {
   search: `
   Search local conversation content
@@ -124,6 +128,7 @@ const COMMAND_HELP: Record<string, string> = {
     --sink=<id>        Use an existing sink by ID
     --remote=<url>     Match by git remote URL
     --json             Output as JSON
+    --restart          Force a controlled runtime restart after saving config
 
   LOW-LEVEL BYO INTEGRATION
     jin sink add <type> ...
@@ -151,6 +156,7 @@ const COMMAND_HELP: Record<string, string> = {
 
   FLAGS
     --remove-sink      Also remove the sink if no routes still reference it
+    --restart          Force a controlled runtime restart after saving config
 
   EXAMPLES
     $ jin disconnect my-repo
@@ -235,10 +241,10 @@ const COMMAND_HELP: Record<string, string> = {
   Manage low-level integration destinations
 
   USAGE
-    jin sink add <type> [flags]
-    jin sink remove <id> [--yes]
-    jin sink disable <id> [--yes]
-    jin sink enable <id> [--yes]
+    jin sink add <type> [flags] [--restart]
+    jin sink remove <id> [--restart]
+    jin sink disable <id> [--restart]
+    jin sink enable <id> [--restart]
     jin sink repush <id>
 
   EXAMPLES
@@ -251,8 +257,8 @@ const COMMAND_HELP: Record<string, string> = {
   Manage low-level routing rules for local conversations
 
   USAGE
-    jin route add --sink=<id> [--remote=<glob>] [--adapter=<id>] [--branch=<glob>] [--name=<glob>] [--yes]
-    jin route remove [--sink=<id>] [--remote=<glob>] [--adapter=<id>] [--branch=<glob>] [--name=<glob>] [--yes]
+    jin route add --sink=<id> [--remote=<glob>] [--adapter=<id>] [--branch=<glob>] [--name=<glob>] [--restart]
+    jin route remove [--sink=<id>] [--remote=<glob>] [--adapter=<id>] [--branch=<glob>] [--name=<glob>] [--restart]
 
   EXAMPLES
     $ jin route add --remote="github.com/acme/*" --sink=team-postgres
@@ -462,7 +468,7 @@ async function main(): Promise<void> {
         userId: (flags["user-id"] || flags.userId) as string | undefined,
         remote: flags.remote as string | undefined,
         json: !!flags.json,
-        yes: !!flags.yes,
+        restart: readConfigRestartFlag(),
       });
       break;
     }
@@ -477,7 +483,7 @@ async function main(): Promise<void> {
       await disconnectCommand(project, {
         "remove-sink": !!flags["remove-sink"],
         removeSink: !!flags.removeSink,
-        yes: !!flags.yes,
+        restart: readConfigRestartFlag(),
       });
       break;
     }
@@ -522,30 +528,30 @@ async function main(): Promise<void> {
             pathStyle:
               parseBooleanFlag(flags["path-style"]) ??
               parseBooleanFlag(flags.pathStyle),
-            yes: !!flags.yes,
+            restart: readConfigRestartFlag(),
           });
           break;
         }
         case "remove":
           if (!sinkId || sinkId.startsWith("--")) {
-            console.error("Usage: jin sink remove <sink-id> [--yes]");
+            console.error("Usage: jin sink remove <sink-id> [--restart]");
             process.exit(1);
           }
-          await sinkRemoveCommand(sinkId, { yes: !!flags.yes });
+          await sinkRemoveCommand(sinkId, { restart: readConfigRestartFlag() });
           break;
         case "disable":
           if (!sinkId || sinkId.startsWith("--")) {
-            console.error("Usage: jin sink disable <sink-id> [--yes]");
+            console.error("Usage: jin sink disable <sink-id> [--restart]");
             process.exit(1);
           }
-          await sinkDisableCommand(sinkId, { yes: !!flags.yes });
+          await sinkDisableCommand(sinkId, { restart: readConfigRestartFlag() });
           break;
         case "enable":
           if (!sinkId || sinkId.startsWith("--")) {
-            console.error("Usage: jin sink enable <sink-id> [--yes]");
+            console.error("Usage: jin sink enable <sink-id> [--restart]");
             process.exit(1);
           }
-          await sinkEnableCommand(sinkId, { yes: !!flags.yes });
+          await sinkEnableCommand(sinkId, { restart: readConfigRestartFlag() });
           break;
         case "repush":
           if (!sinkId || sinkId.startsWith("--")) {
@@ -570,7 +576,7 @@ async function main(): Promise<void> {
         adapter: flags.adapter as string | undefined,
         branch: flags.branch as string | undefined,
         name: flags.name as string | undefined,
-        yes: !!flags.yes,
+        restart: readConfigRestartFlag(),
       };
 
       switch (action) {

--- a/src/pipeline/diagnostic.ts
+++ b/src/pipeline/diagnostic.ts
@@ -457,6 +457,10 @@ export class DiagnosticLogger {
 
 function workMeta(work: PipelineWorkItem): Record<string, unknown> {
   switch (work.kind) {
+    case "config-reload":
+      return {
+        source: work.source,
+      };
     case "ingest-adapter":
       return {
         adapterId: work.adapterId,

--- a/src/pipeline/loop.ts
+++ b/src/pipeline/loop.ts
@@ -268,6 +268,7 @@ export async function runPipeline(
               activeAdapters.map((adapter) => adapter.id),
               performance.now() - t0,
             );
+            enqueuePush();
             break;
           }
           case "reconcile-adapters": {
@@ -373,6 +374,7 @@ export async function runPipeline(
                 logger,
                 diag,
                 shouldContinueSinkPush: options.shouldContinueSinkPush,
+                getCurrentDeliverySnapshot: options.getCurrentDeliverySnapshot,
               },
             );
             diag?.pushResult(summary, performance.now() - t0, summary.sinkBreakdown);
@@ -414,6 +416,7 @@ export async function runPipeline(
               logger,
               diag,
               shouldContinueSinkPush: options.shouldContinueSinkPush,
+              getCurrentDeliverySnapshot: options.getCurrentDeliverySnapshot,
             });
             shouldStop = true;
             break;

--- a/src/pipeline/loop.ts
+++ b/src/pipeline/loop.ts
@@ -113,6 +113,7 @@ export async function runPipeline(
   let rssWarningActive = false;
   let activeScanIntervalMs: number | null | undefined;
   let periodicTimer: ReturnType<typeof setInterval> | null = null;
+  let skipShutdownFlush = false;
 
   resetPeriodicTimer(currentScanIntervalMs());
 
@@ -247,7 +248,12 @@ export async function runPipeline(
         switch (work.kind) {
           case "config-reload": {
             const t0 = performance.now();
-            await options.onConfigReload?.(work.source);
+            const reloadResult = await options.onConfigReload?.(work.source);
+            if (reloadResult === false) {
+              skipShutdownFlush = true;
+              shouldStop = true;
+              break;
+            }
             activeAdapters = await resolveAdapters(options.adapterSource);
             if (watcherStarted) {
               watcher.reconcile(activeAdapters);
@@ -366,12 +372,18 @@ export async function runPipeline(
                 batchSize: pushBatchSize,
                 logger,
                 diag,
+                shouldContinueSinkPush: options.shouldContinueSinkPush,
               },
             );
             diag?.pushResult(summary, performance.now() - t0, summary.sinkBreakdown);
             break;
           }
           case "shutdown-flush": {
+            if (work.flush === false) {
+              shouldStop = true;
+              break;
+            }
+
             await ingestAll(
               activeAdapters,
               options.store,
@@ -401,6 +413,7 @@ export async function runPipeline(
               batchSize: pushBatchSize,
               logger,
               diag,
+              shouldContinueSinkPush: options.shouldContinueSinkPush,
             });
             shouldStop = true;
             break;
@@ -514,9 +527,11 @@ export async function runPipeline(
     resetPeriodicTimer(null);
 
     abandonedWorkItems = queue.discard(
-      (item) => item.kind !== "shutdown-flush",
+      skipShutdownFlush
+        ? () => true
+        : (item) => item.kind !== "shutdown-flush",
     );
-    queue.enqueue({ kind: "shutdown-flush" });
+    queue.enqueue({ kind: "shutdown-flush", flush: !skipShutdownFlush });
     diag?.queueEvent("queued", "shutdown-flush");
   }
 

--- a/src/pipeline/loop.ts
+++ b/src/pipeline/loop.ts
@@ -111,23 +111,10 @@ export async function runPipeline(
   let handedOffWorkItems = 0;
   const idleResolvers: Array<() => void> = [];
   let rssWarningActive = false;
+  let activeScanIntervalMs: number | null | undefined;
+  let periodicTimer: ReturnType<typeof setInterval> | null = null;
 
-  const scanIntervalMs =
-    options.scanIntervalMs === undefined
-      ? DEFAULT_SCAN_INTERVAL_MS
-      : options.scanIntervalMs;
-  const periodicTimer =
-    scanIntervalMs && scanIntervalMs > 0
-      ? setInterval(() => {
-          diag?.periodicTick();
-          enqueue({ kind: "reconcile-adapters" });
-          enqueue({
-            kind: "ingest-all",
-            hint: { kind: "periodic-scan" },
-          });
-          enqueue({ kind: "push" });
-        }, scanIntervalMs)
-      : null;
+  resetPeriodicTimer(currentScanIntervalMs());
 
   const coordinatorDone = coordinator();
 
@@ -145,6 +132,7 @@ export async function runPipeline(
 
   return {
     enqueue,
+    reloadConfig,
     waitForIdle,
     shutdown,
   };
@@ -160,6 +148,23 @@ export async function runPipeline(
       work.kind,
       work.kind === "ingest-adapter" ? work.adapterId : undefined,
     );
+    if (enqueueResult === "handed-off") {
+      handedOffWorkItems += 1;
+    }
+    resolveIdleIfNeeded();
+    return true;
+  }
+
+  function reloadConfig(source: "config-file" | "command"): boolean {
+    if (stopping) {
+      return false;
+    }
+
+    const enqueueResult = queue.enqueuePriority({
+      kind: "config-reload",
+      source,
+    });
+    diag?.queueEvent(enqueueResult, "config-reload");
     if (enqueueResult === "handed-off") {
       handedOffWorkItems += 1;
     }
@@ -208,7 +213,7 @@ export async function runPipeline(
     }
 
     await Promise.allSettled(
-      options.sinks.map(async (sink) => {
+      currentSinks().map(async (sink) => {
         try {
           await sink.close();
         } catch (error) {
@@ -240,6 +245,25 @@ export async function runPipeline(
         enforceRssBudget(`pipeline work item ${work.kind}`);
 
         switch (work.kind) {
+          case "config-reload": {
+            const t0 = performance.now();
+            await options.onConfigReload?.(work.source);
+            activeAdapters = await resolveAdapters(options.adapterSource);
+            if (watcherStarted) {
+              watcher.reconcile(activeAdapters);
+              diag?.watcherReconciled(
+                activeAdapters.map((adapter) => adapter.id),
+                deferWatcherStart,
+              );
+            }
+            resetPeriodicTimer(currentScanIntervalMs());
+            diag?.reconcileResult(
+              activeAdapters.length,
+              activeAdapters.map((adapter) => adapter.id),
+              performance.now() - t0,
+            );
+            break;
+          }
           case "reconcile-adapters": {
             const t0 = performance.now();
             activeAdapters = await resolveAdapters(options.adapterSource);
@@ -263,8 +287,8 @@ export async function runPipeline(
                 reclaimBetweenAdapters: true,
                 trackChangedConversationIds: false,
                 logger,
-                workerIngest: options.workerIngest,
-                discoveryCache: options.discoveryCache,
+                workerIngest: currentWorkerIngest(),
+                discoveryCache: currentDiscoveryCache(),
                 onDiscoveryResult: (info) => {
                   diag?.discoveryResult(info);
                 },
@@ -308,8 +332,8 @@ export async function runPipeline(
                 reclaimBetweenAdapters: true,
                 trackChangedConversationIds: false,
                 logger,
-                workerIngest: options.workerIngest,
-                discoveryCache: options.discoveryCache,
+                workerIngest: currentWorkerIngest(),
+                discoveryCache: currentDiscoveryCache(),
                 onDiscoveryResult: (info) => {
                   diag?.discoveryResult(info);
                 },
@@ -334,11 +358,16 @@ export async function runPipeline(
           }
           case "push": {
             const t0 = performance.now();
-            const summary = await pushDirty(options.store, options.sinks, options.routes, {
-              batchSize: pushBatchSize,
-              logger,
-              diag,
-            });
+            const summary = await pushDirty(
+              options.store,
+              currentSinks(),
+              currentRoutes(),
+              {
+                batchSize: pushBatchSize,
+                logger,
+                diag,
+              },
+            );
             diag?.pushResult(summary, performance.now() - t0, summary.sinkBreakdown);
             break;
           }
@@ -353,8 +382,8 @@ export async function runPipeline(
                 loadConversationTimeoutMs,
                 trackChangedConversationIds: false,
                 logger,
-                workerIngest: options.workerIngest,
-                discoveryCache: options.discoveryCache,
+                workerIngest: currentWorkerIngest(),
+                discoveryCache: currentDiscoveryCache(),
                 onDiscoveryResult: (info) => {
                   diag?.discoveryResult(info);
                 },
@@ -368,7 +397,7 @@ export async function runPipeline(
                 },
               },
             );
-            await pushDirty(options.store, options.sinks, options.routes, {
+            await pushDirty(options.store, currentSinks(), currentRoutes(), {
               batchSize: pushBatchSize,
               logger,
               diag,
@@ -407,6 +436,72 @@ export async function runPipeline(
     enqueue({ kind: "push" });
   }
 
+  function currentSinks(): ReadonlyArray<typeof options.sinks[number]> {
+    return options.getSinks?.() ?? options.sinks;
+  }
+
+  function currentRoutes(): ReadonlyArray<typeof options.routes[number]> {
+    return options.getRoutes?.() ?? options.routes;
+  }
+
+  function currentWorkerIngest(): typeof options.workerIngest {
+    if (!options.workerIngest) {
+      return undefined;
+    }
+
+    return {
+      ...options.workerIngest,
+      adapterConfigs:
+        options.workerIngest.getAdapterConfigs?.() ??
+        options.workerIngest.adapterConfigs,
+    };
+  }
+
+  function currentDiscoveryCache(): typeof options.discoveryCache {
+    if (!options.discoveryCache) {
+      return undefined;
+    }
+
+    return {
+      ...options.discoveryCache,
+      adapterConfigs:
+        options.discoveryCache.getAdapterConfigs?.() ??
+        options.discoveryCache.adapterConfigs,
+    };
+  }
+
+  function resetPeriodicTimer(scanIntervalMs: number | null): void {
+    if (scanIntervalMs === activeScanIntervalMs) {
+      return;
+    }
+
+    if (periodicTimer) {
+      clearInterval(periodicTimer);
+      periodicTimer = null;
+    }
+
+    activeScanIntervalMs = scanIntervalMs;
+    if (scanIntervalMs === null || scanIntervalMs <= 0) {
+      return;
+    }
+
+    periodicTimer = setInterval(() => {
+      diag?.periodicTick();
+      enqueue({ kind: "reconcile-adapters" });
+      enqueue({
+        kind: "ingest-all",
+        hint: { kind: "periodic-scan" },
+      });
+      enqueue({ kind: "push" });
+    }, scanIntervalMs);
+  }
+
+  function currentScanIntervalMs(): number | null {
+    return normalizeScanIntervalMs(
+      options.getScanIntervalMs?.() ?? options.scanIntervalMs,
+    );
+  }
+
   function initiateShutdown(): void {
     if (shutdownInitiated) {
       return;
@@ -416,9 +511,7 @@ export async function runPipeline(
     stopping = true;
     watcher.close();
 
-    if (periodicTimer) {
-      clearInterval(periodicTimer);
-    }
+    resetPeriodicTimer(null);
 
     abandonedWorkItems = queue.discard(
       (item) => item.kind !== "shutdown-flush",
@@ -478,6 +571,22 @@ async function resolveAdapters(
   }
 
   return [...adapterSource];
+}
+
+function normalizeScanIntervalMs(
+  scanIntervalMs: number | null | undefined,
+): number | null {
+  if (scanIntervalMs === null) {
+    return null;
+  }
+  if (scanIntervalMs === undefined) {
+    return DEFAULT_SCAN_INTERVAL_MS;
+  }
+  if (!Number.isFinite(scanIntervalMs) || scanIntervalMs <= 0) {
+    return null;
+  }
+
+  return Math.floor(scanIntervalMs);
 }
 
 function normalizeBatchSize(

--- a/src/pipeline/push.ts
+++ b/src/pipeline/push.ts
@@ -12,9 +12,18 @@ export interface PushOptions {
   diag?: DiagnosticLogger | null;
   reason?: DiagnosticPushReason;
   sampleIntervalMs?: number;
+  getCurrentDeliverySnapshot?: (
+    sinkId: string,
+  ) => PushDeliverySnapshot | Promise<PushDeliverySnapshot>;
   shouldContinueSinkPush?: (
     sinkId: string,
   ) => boolean | Promise<boolean>;
+}
+
+export interface PushDeliverySnapshot {
+  generationToken: string;
+  sinks: ReadonlyArray<{ id: string; enabled?: boolean }>;
+  routes: ReadonlyArray<RouteConfig>;
 }
 
 const NOOP_LOGGER: PipelineLogger = {
@@ -58,66 +67,70 @@ export async function pushDirty(
     if (dirtyConversationIds.length === 0) {
       continue;
     }
-    const routedConversationIds = dirtyConversationIds.filter((conversationId) =>
-      conversationTargetsSink(store, routes, sink.id, conversationId),
-    );
-    const staleConversations =
-      dirtyConversationIds.length - routedConversationIds.length;
-
-    const totalBatches = Math.ceil(routedConversationIds.length / batchSize);
+    const totalBatches = Math.ceil(dirtyConversationIds.length / batchSize);
     const sinkStartedAt = performance.now();
     diag?.pushStart({
       sinkId: sink.id,
       reason,
-      dirtyConversations: routedConversationIds.length,
-      staleConversations,
+      dirtyConversations: dirtyConversationIds.length,
+      staleConversations: 0,
       batchSize,
       batchCount: totalBatches,
     });
 
-    if (routedConversationIds.length === 0) {
-      diag?.pushSinkResult({
-        sinkId: sink.id,
-        reason,
-        dirtyConversations: 0,
-        staleConversations,
-        pushed: 0,
-        failed: 0,
-        skippedConversations: 0,
-        durationMs: performance.now() - sinkStartedAt,
-      });
-      continue;
-    }
-
     for (
       let start = 0, batchIndex = 0;
-      start < routedConversationIds.length;
+      start < dirtyConversationIds.length;
       start += batchSize, batchIndex += 1
     ) {
-      if (!(await shouldContinueSinkPush(sink.id, options, logger))) {
-        const remainingConversations = routedConversationIds.length - start;
+      const deliverySnapshot = await getCurrentDeliverySnapshot(
+        sink.id,
+        routes,
+        sink,
+        options,
+        logger,
+      );
+
+      if (
+        !deliverySnapshot ||
+        !(await shouldContinueSinkPush(sink.id, options, logger)) ||
+        !deliverySnapshotAllowsSink(deliverySnapshot, sink.id) ||
+        !deliverySnapshotRoutesSink(deliverySnapshot, sink.id)
+      ) {
+        const remainingConversations = dirtyConversationIds.length - start;
         sinkSkipped += remainingConversations;
         logger.warn(
-          `Stopping push for disabled sink ${sink.id}; ${remainingConversations} conversation${remainingConversations === 1 ? "" : "s"} remain queued.`,
+          `Stopping push for inactive sink ${sink.id}; ${remainingConversations} conversation${remainingConversations === 1 ? "" : "s"} remain queued.`,
         );
         break;
       }
 
-      const batchConversationIds = routedConversationIds.slice(
+      const dirtyBatchConversationIds = dirtyConversationIds.slice(
         start,
         start + batchSize,
       );
+      const batchConversationIds = dirtyBatchConversationIds.filter((conversationId) =>
+        conversationTargetsSink(
+          store,
+          deliverySnapshot.routes,
+          sink.id,
+          conversationId,
+        ),
+      );
+      const staleConversations =
+        dirtyBatchConversationIds.length - batchConversationIds.length;
       const payloads = batchConversationIds
         .map((conversationId) => createPayload(store, conversationId))
         .filter((payload): payload is PushPayload => payload !== null);
-      const skippedConversations = batchConversationIds.length - payloads.length;
+      const skippedConversations =
+        staleConversations + batchConversationIds.length - payloads.length;
       const selectedConversations = Math.min(
-        routedConversationIds.length,
-        start + batchConversationIds.length,
+        dirtyConversationIds.length,
+        start + dirtyBatchConversationIds.length,
       );
       const remainingConversations = Math.max(
         0,
-        routedConversationIds.length - selectedConversations,
+        dirtyConversationIds.length - selectedConversations,
       );
 
       sinkSkipped += skippedConversations;
@@ -126,18 +139,18 @@ export async function pushDirty(
         reason,
         batchIndex: batchIndex + 1,
         batchCount: totalBatches,
-        totalDirtyConversations: routedConversationIds.length,
+        totalDirtyConversations: dirtyConversationIds.length,
         selectedConversations,
         remainingConversations,
-        dirtyInBatch: batchConversationIds.length,
+        dirtyInBatch: dirtyBatchConversationIds.length,
         payloadCount: payloads.length,
         skippedConversations,
-        dirtyConversationIds: batchConversationIds,
+        dirtyConversationIds: dirtyBatchConversationIds,
         payloadConversationIds: payloads.map((payload) => payload.conversation.id),
       });
 
       if (payloads.length === 0) {
-        if (start + batchSize < routedConversationIds.length) {
+        if (start + batchSize < dirtyConversationIds.length) {
           await Bun.sleep(0);
         }
         continue;
@@ -155,7 +168,7 @@ export async function pushDirty(
               reason,
               batchIndex: batchIndex + 1,
               batchCount: totalBatches,
-              totalDirtyConversations: routedConversationIds.length,
+              totalDirtyConversations: dirtyConversationIds.length,
               selectedConversations,
               remainingConversations,
               inFlightConversations: payloads.length,
@@ -173,6 +186,20 @@ export async function pushDirty(
           result.failed,
           logger,
         );
+        if (
+          await deliveryGenerationChanged(
+            sink.id,
+            deliverySnapshot.generationToken,
+            options,
+            logger,
+          )
+        ) {
+          sinkSkipped += payloads.length;
+          logger.warn(
+            `Config changed while sink ${sink.id} push was in flight; leaving ${payloads.length} conversation${payloads.length === 1 ? "" : "s"} dirty for retry.`,
+          );
+          continue;
+        }
 
         for (const payload of payloads) {
           const error = errorsByConversation.get(payload.conversation.id);
@@ -185,7 +212,7 @@ export async function pushDirty(
               conversationId: payload.conversation.id,
               attemptedRevision: payload.attemptedRevision,
               batchIndex: batchIndex + 1,
-              totalDirtyConversations: routedConversationIds.length,
+              totalDirtyConversations: dirtyConversationIds.length,
               selectedConversations,
               ok: false,
               error,
@@ -207,7 +234,7 @@ export async function pushDirty(
             conversationId: payload.conversation.id,
             attemptedRevision: payload.attemptedRevision,
             batchIndex: batchIndex + 1,
-            totalDirtyConversations: routedConversationIds.length,
+            totalDirtyConversations: dirtyConversationIds.length,
             selectedConversations,
             ok: true,
           });
@@ -220,6 +247,20 @@ export async function pushDirty(
         }
       } catch (error) {
         logger.error(`Sink ${sink.id} failed during push`, error);
+        if (
+          await deliveryGenerationChanged(
+            sink.id,
+            deliverySnapshot.generationToken,
+            options,
+            logger,
+          )
+        ) {
+          sinkSkipped += payloads.length;
+          logger.warn(
+            `Config changed while failed sink ${sink.id} push was in flight; leaving ${payloads.length} conversation${payloads.length === 1 ? "" : "s"} dirty for retry.`,
+          );
+          continue;
+        }
         const message = errorToMessage(error);
 
         for (const payload of payloads) {
@@ -231,7 +272,7 @@ export async function pushDirty(
             conversationId: payload.conversation.id,
             attemptedRevision: payload.attemptedRevision,
             batchIndex: batchIndex + 1,
-            totalDirtyConversations: routedConversationIds.length,
+            totalDirtyConversations: dirtyConversationIds.length,
             selectedConversations,
             ok: false,
             error: message,
@@ -245,7 +286,7 @@ export async function pushDirty(
         }
       }
 
-      if (start + batchSize < routedConversationIds.length) {
+      if (start + batchSize < dirtyConversationIds.length) {
         await Bun.sleep(0);
       }
     }
@@ -253,8 +294,8 @@ export async function pushDirty(
     diag?.pushSinkResult({
       sinkId: sink.id,
       reason,
-      dirtyConversations: routedConversationIds.length,
-      staleConversations,
+      dirtyConversations: dirtyConversationIds.length,
+      staleConversations: sinkSkipped,
       pushed: sinkPushed,
       failed: sinkFailed,
       skippedConversations: sinkSkipped,
@@ -269,6 +310,67 @@ export async function pushDirty(
     failedConversations,
     sinkBreakdown,
   };
+}
+
+async function getCurrentDeliverySnapshot(
+  sinkId: string,
+  routes: ReadonlyArray<RouteConfig>,
+  sink: Sink,
+  options: PushOptions,
+  logger: PipelineLogger,
+): Promise<PushDeliverySnapshot | null> {
+  if (!options.getCurrentDeliverySnapshot) {
+    return {
+      generationToken: "",
+      sinks: [sink],
+      routes,
+    };
+  }
+
+  try {
+    return await options.getCurrentDeliverySnapshot(sinkId);
+  } catch (error) {
+    logger.warn(
+      `Stopping push for sink ${sinkId}; current config state could not be loaded: ${errorToMessage(error)}`,
+    );
+    return null;
+  }
+}
+
+function deliverySnapshotAllowsSink(
+  snapshot: PushDeliverySnapshot,
+  sinkId: string,
+): boolean {
+  const sink = snapshot.sinks.find((candidate) => candidate.id === sinkId);
+  return sink !== undefined && sink.enabled !== false;
+}
+
+function deliverySnapshotRoutesSink(
+  snapshot: PushDeliverySnapshot,
+  sinkId: string,
+): boolean {
+  return snapshot.routes.some((route) => route.sinks.includes(sinkId));
+}
+
+async function deliveryGenerationChanged(
+  sinkId: string,
+  previousToken: string,
+  options: PushOptions,
+  logger: PipelineLogger,
+): Promise<boolean> {
+  if (!options.getCurrentDeliverySnapshot || previousToken.length === 0) {
+    return false;
+  }
+
+  try {
+    const current = await options.getCurrentDeliverySnapshot(sinkId);
+    return current.generationToken !== previousToken;
+  } catch (error) {
+    logger.warn(
+      `Treating sink ${sinkId} push result as uncommitted because current config state could not be loaded: ${errorToMessage(error)}`,
+    );
+    return true;
+  }
 }
 
 function conversationTargetsSink(

--- a/src/pipeline/push.ts
+++ b/src/pipeline/push.ts
@@ -12,6 +12,9 @@ export interface PushOptions {
   diag?: DiagnosticLogger | null;
   reason?: DiagnosticPushReason;
   sampleIntervalMs?: number;
+  shouldContinueSinkPush?: (
+    sinkId: string,
+  ) => boolean | Promise<boolean>;
 }
 
 const NOOP_LOGGER: PipelineLogger = {
@@ -91,6 +94,15 @@ export async function pushDirty(
       start < routedConversationIds.length;
       start += batchSize, batchIndex += 1
     ) {
+      if (!(await shouldContinueSinkPush(sink.id, options, logger))) {
+        const remainingConversations = routedConversationIds.length - start;
+        sinkSkipped += remainingConversations;
+        logger.warn(
+          `Stopping push for disabled sink ${sink.id}; ${remainingConversations} conversation${remainingConversations === 1 ? "" : "s"} remain queued.`,
+        );
+        break;
+      }
+
       const batchConversationIds = routedConversationIds.slice(
         start,
         start + batchSize,
@@ -386,6 +398,25 @@ function errorToMessage(error: unknown): string {
   }
 
   return String(error);
+}
+
+async function shouldContinueSinkPush(
+  sinkId: string,
+  options: PushOptions,
+  logger: PipelineLogger,
+): Promise<boolean> {
+  if (!options.shouldContinueSinkPush) {
+    return true;
+  }
+
+  try {
+    return (await options.shouldContinueSinkPush(sinkId)) !== false;
+  } catch (error) {
+    logger.warn(
+      `Stopping push for sink ${sinkId}; current config state could not be verified: ${errorToMessage(error)}`,
+    );
+    return false;
+  }
 }
 
 function isSinkEnabled(sink: Sink): boolean {

--- a/src/pipeline/queue.ts
+++ b/src/pipeline/queue.ts
@@ -32,6 +32,21 @@ export class WorkQueue {
     });
   }
 
+  enqueuePriority(item: PipelineWorkItem): WorkQueueEnqueueResult {
+    if (this.hasEquivalentQueuedItem(item)) {
+      return "coalesced";
+    }
+
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter(item);
+      return "handed-off";
+    }
+
+    this.items.unshift(item);
+    return "queued";
+  }
+
   discard(
     predicate: (item: PipelineWorkItem) => boolean = () => true,
   ): number {
@@ -100,6 +115,16 @@ export class WorkQueue {
     }
 
     return false;
+  }
+
+  private hasEquivalentQueuedItem(next: PipelineWorkItem): boolean {
+    return this.items.some((item) => {
+      if (item.kind !== next.kind) {
+        return false;
+      }
+
+      return item.kind === "config-reload" && next.kind === "config-reload";
+    });
   }
 }
 

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -10,7 +10,7 @@ export type PipelineWorkItem =
   | { kind: "ingest-all"; hint: ChangeHint }
   | { kind: "ingest-adapter"; adapterId: string; hint: ChangeHint }
   | { kind: "push" }
-  | { kind: "shutdown-flush" };
+  | { kind: "shutdown-flush"; flush?: boolean };
 
 export type QueueablePipelineWorkItem = Exclude<
   PipelineWorkItem,
@@ -82,7 +82,10 @@ export interface RunPipelineOptions {
   diagnosticLogPath?: string;
   onConfigReload?: (
     source: "config-file" | "command",
-  ) => void | Promise<void>;
+  ) => boolean | void | Promise<boolean | void>;
+  shouldContinueSinkPush?: (
+    sinkId: string,
+  ) => boolean | Promise<boolean>;
   workerIngest?: {
     command: string[];
     adapterConfigs: Record<string, AdapterConfig>;

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -3,6 +3,7 @@ import type { AdapterConfig, RouteConfig } from "../contracts/config";
 import type { Sink } from "../contracts/sinks";
 import type { ConversationStore } from "../contracts/store";
 import type { SqliteDiscoveryCache } from "../db/discovery-cache";
+import type { PushDeliverySnapshot } from "./push";
 
 export type PipelineWorkItem =
   | { kind: "reconcile-adapters" }
@@ -86,6 +87,9 @@ export interface RunPipelineOptions {
   shouldContinueSinkPush?: (
     sinkId: string,
   ) => boolean | Promise<boolean>;
+  getCurrentDeliverySnapshot?: (
+    sinkId: string,
+  ) => PushDeliverySnapshot | Promise<PushDeliverySnapshot>;
   workerIngest?: {
     command: string[];
     adapterConfigs: Record<string, AdapterConfig>;

--- a/src/pipeline/types.ts
+++ b/src/pipeline/types.ts
@@ -6,6 +6,7 @@ import type { SqliteDiscoveryCache } from "../db/discovery-cache";
 
 export type PipelineWorkItem =
   | { kind: "reconcile-adapters" }
+  | { kind: "config-reload"; source: "config-file" | "command" }
   | { kind: "ingest-all"; hint: ChangeHint }
   | { kind: "ingest-adapter"; adapterId: string; hint: ChangeHint }
   | { kind: "push" }
@@ -60,6 +61,9 @@ export interface RunPipelineOptions {
   store: ConversationStore;
   sinks: ReadonlyArray<Sink>;
   routes: ReadonlyArray<RouteConfig>;
+  getSinks?: () => ReadonlyArray<Sink>;
+  getRoutes?: () => ReadonlyArray<RouteConfig>;
+  getScanIntervalMs?: () => number | null | undefined;
   logger?: PipelineLogger;
   ingestBatchSize?: number;
   pushBatchSize?: number;
@@ -76,13 +80,18 @@ export interface RunPipelineOptions {
     result: PipelineShutdownResult,
   ) => void | Promise<void>;
   diagnosticLogPath?: string;
+  onConfigReload?: (
+    source: "config-file" | "command",
+  ) => void | Promise<void>;
   workerIngest?: {
     command: string[];
     adapterConfigs: Record<string, AdapterConfig>;
+    getAdapterConfigs?: () => Record<string, AdapterConfig>;
   };
   discoveryCache?: {
     store: SqliteDiscoveryCache;
     adapterConfigs: Record<string, AdapterConfig>;
+    getAdapterConfigs?: () => Record<string, AdapterConfig>;
   };
 }
 
@@ -93,6 +102,7 @@ export interface PipelineShutdownResult {
 
 export interface PipelineHandle {
   enqueue(work: QueueablePipelineWorkItem): boolean;
+  reloadConfig(source: "config-file" | "command"): boolean;
   waitForIdle(): Promise<void>;
   shutdown(): Promise<PipelineShutdownResult>;
 }

--- a/test/cli-surface-cleanup.test.ts
+++ b/test/cli-surface-cleanup.test.ts
@@ -40,6 +40,22 @@ test("jin help for connect/start/stop no longer shows removed compatibility flag
   expect(stop.stdout).not.toContain("--ui");
 });
 
+test("jin help for config mutations advertises --restart, not --yes", async () => {
+  const connect = await runCli(["help", "connect"]);
+  const disconnect = await runCli(["help", "disconnect"]);
+  const sink = await runCli(["help", "sink"]);
+  const route = await runCli(["help", "route"]);
+
+  expect(connect.stdout).toContain("--restart");
+  expect(connect.stdout).not.toContain("--yes");
+  expect(disconnect.stdout).toContain("--restart");
+  expect(disconnect.stdout).not.toContain("--yes");
+  expect(sink.stdout).toContain("--restart");
+  expect(sink.stdout).not.toContain("--yes");
+  expect(route.stdout).toContain("--restart");
+  expect(route.stdout).not.toContain("--yes");
+});
+
 test("jin help for desktop documents optional install and update flow", async () => {
   const result = await runCli(["help", "desktop"]);
 

--- a/test/config-mutation-control.test.ts
+++ b/test/config-mutation-control.test.ts
@@ -225,7 +225,7 @@ describe("config mutation and control commands", () => {
     ]);
   });
 
-  test("sink add writes durable config and requires explicit restart by default", async () => {
+  test("sink add writes durable config and live-reloads by default", async () => {
     watcherState = {
       name: "watcher",
       status: "running",
@@ -254,7 +254,7 @@ describe("config mutation and control commands", () => {
       },
     ]);
     expect(restartCalls).toHaveLength(0);
-    expect(console_.logs.join("\n")).toContain("Restart jin to apply config changes.");
+    expect(console_.logs.join("\n")).toContain("Running runtime will reload config shortly.");
   });
 
   test("sink add refuses duplicate transport endpoints when export identity differs", async () => {
@@ -329,7 +329,7 @@ describe("config mutation and control commands", () => {
     expect(restartCalls).toEqual([{ service: true }]);
   });
 
-  test("manual protected-source opt-in changes the startup notice after restart", async () => {
+  test("manual protected-source opt-in changes the startup notice after config update", async () => {
     const config = defaultConfig();
     mockAdapters = [];
 

--- a/test/config-mutation-control.test.ts
+++ b/test/config-mutation-control.test.ts
@@ -6,7 +6,7 @@ import {
   mock,
   test,
 } from "bun:test";
-import { mkdtempSync } from "fs";
+import { existsSync, mkdtempSync, readdirSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import type { ConversationBundle } from "../src/contracts/conversations";
@@ -99,7 +99,12 @@ mock.module("../src/commands/ingest", () => ({
   ingestCommand: async () => {},
 }));
 
-const { defaultConfig } = await import("../src/config");
+const {
+  configLockPath,
+  defaultConfig,
+  saveConfig,
+  updateConfig,
+} = await import("../src/config");
 const { encodeTeamConfig } = await import("../src/sinks/types");
 const { connectCommand } = await import("../src/commands/connect");
 const { watchCommand } = await import("../src/commands/watch");
@@ -145,6 +150,81 @@ afterEach(() => {
 });
 
 describe("config mutation and control commands", () => {
+  test("saveConfig writes atomically and releases the config lock", async () => {
+    const config = defaultConfig();
+    config.sinks = [
+      {
+        id: "postgres-team",
+        type: "postgres",
+        enabled: true,
+        connectionString: "postgresql://localhost:5432/jin",
+      },
+    ];
+
+    await saveConfig(config);
+
+    const nextConfig = await readTestConfig(tempDir);
+    expect(nextConfig.sinks).toEqual(config.sinks);
+    expect(existsSync(configLockPath())).toBe(false);
+    expect(readdirSync(tempDir).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+  });
+
+  test("updateConfig does not persist partial mutations when the mutator fails", async () => {
+    const config = defaultConfig();
+    await writeTestConfig(tempDir, config);
+
+    await expect(
+      updateConfig((nextConfig) => {
+        nextConfig.sinks.push({
+          id: "postgres-team",
+          type: "postgres",
+          enabled: true,
+          connectionString: "postgresql://localhost:5432/jin",
+        });
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    const nextConfig = await readTestConfig(tempDir);
+    expect(nextConfig.sinks).toEqual([]);
+  });
+
+  test("updateConfig serializes concurrent mutations so later saves do not clobber earlier changes", async () => {
+    const config = defaultConfig();
+    await writeTestConfig(tempDir, config);
+
+    await Promise.all([
+      updateConfig(async (nextConfig) => {
+        await Bun.sleep(20);
+        nextConfig.sinks.push({
+          id: "postgres-team",
+          type: "postgres",
+          enabled: true,
+          connectionString: "postgresql://localhost:5432/jin",
+        });
+        return "sink";
+      }),
+      updateConfig((nextConfig) => {
+        nextConfig.routes.push({
+          match: { remote: "github.com/org/alpha" },
+          sinks: ["postgres-team"],
+        });
+        return "route";
+      }),
+    ]);
+
+    const nextConfig = await readTestConfig(tempDir);
+    expect(nextConfig.sinks.map((sink: { id: string }) => sink.id)).toEqual([
+      "postgres-team",
+    ]);
+    expect(nextConfig.routes).toEqual([
+      {
+        match: { remote: "github.com/org/alpha" },
+        sinks: ["postgres-team"],
+      },
+    ]);
+  });
+
   test("sink add writes durable config and requires explicit restart by default", async () => {
     watcherState = {
       name: "watcher",

--- a/test/config-mutation-control.test.ts
+++ b/test/config-mutation-control.test.ts
@@ -1,4 +1,5 @@
 import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -169,6 +170,10 @@ afterEach(() => {
   exitMock.restore();
   delete process.env.JIN_CONFIG_DIR;
   removeDirWithRetry(tempDir);
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe("config mutation and control commands", () => {
@@ -394,7 +399,26 @@ describe("config mutation and control commands", () => {
     expect(nextConfig.sinks).toEqual(config.sinks);
   });
 
-  test("route add --yes performs a service-aware controlled restart", async () => {
+  test("sink add health check runs outside the config lock", async () => {
+    const lockStates: boolean[] = [];
+    fakeSink = {
+      ...createFakeSink(),
+      healthCheck: async () => {
+        lockStates.push(existsSync(configLockPath()));
+        return { ok: true };
+      },
+    };
+
+    await sinkAddCommand("postgres", {
+      id: "postgres-team",
+      connectionString: "postgresql://localhost:5432/jin",
+    });
+
+    expect(lockStates).toEqual([false]);
+    expect(existsSync(configLockPath())).toBe(false);
+  });
+
+  test("route add --restart performs a service-aware controlled restart", async () => {
     const config = defaultConfig();
     config.sinks = [
       {
@@ -422,7 +446,7 @@ describe("config mutation and control commands", () => {
     await routeAddCommand({
       remote: "https://github.com/org/alpha.git",
       sink: "postgres-team",
-      yes: true,
+      restart: true,
     });
 
     const nextConfig = await readTestConfig(tempDir);
@@ -516,7 +540,7 @@ describe("config mutation and control commands", () => {
     expect(restartCalls).toHaveLength(0);
   });
 
-  test("sink enable and disable --yes perform a controlled restart", async () => {
+  test("sink enable and disable --restart perform a controlled restart", async () => {
     const config = defaultConfig();
     config.sinks = [
       {
@@ -541,7 +565,7 @@ describe("config mutation and control commands", () => {
       issues: [],
     };
 
-    await sinkDisableCommand("postgres-team", { yes: true });
+    await sinkDisableCommand("postgres-team", { restart: true });
 
     let nextConfig = await readTestConfig(tempDir);
     expect(nextConfig.sinks[0].enabled).toBe(false);
@@ -549,7 +573,7 @@ describe("config mutation and control commands", () => {
     expect(restartCalls).toEqual([{ service: true }]);
 
     restartCalls = [];
-    await sinkEnableCommand("postgres-team", { yes: true });
+    await sinkEnableCommand("postgres-team", { restart: true });
 
     nextConfig = await readTestConfig(tempDir);
     expect(nextConfig.sinks[0].enabled).toBe(true);

--- a/test/config-mutation-control.test.ts
+++ b/test/config-mutation-control.test.ts
@@ -27,6 +27,15 @@ let watcherState: any;
 let runtimeStatus: any;
 let restartCalls: any[] = [];
 let markRuntimeRunningCalls: Array<{ mode: string; issues: any[] }> = [];
+let configReloadRequests: any[] = [];
+let configReloadResult:
+  | { status: "accepted"; statusCode: number; message: string }
+  | { status: "rejected"; statusCode: number; message: string }
+  | { status: "failed"; message: string } = {
+    status: "accepted",
+    statusCode: 202,
+    message: "Config reload accepted.",
+  };
 let runtimePaths = {
   configDir: "",
   configPath: "",
@@ -83,6 +92,13 @@ mock.module("../src/commands/start", () => ({
   },
 }));
 
+mock.module("../src/api/client", () => ({
+  requestDaemonConfigReload: async (opts: unknown) => {
+    configReloadRequests.push(opts ?? {});
+    return configReloadResult;
+  },
+}));
+
 mock.module("../src/adapters/registry", () => ({
   allAdapters: () => mockAdapters,
   createAdapter: (adapterId: string) =>
@@ -135,6 +151,12 @@ beforeEach(() => {
   runtimeStatus = { state: "stopped", issues: [] };
   restartCalls = [];
   markRuntimeRunningCalls = [];
+  configReloadRequests = [];
+  configReloadResult = {
+    status: "accepted",
+    statusCode: 202,
+    message: "Config reload accepted.",
+  };
   mockAdapters = [];
   fakeSink = createFakeSink();
   console_ = captureConsole();
@@ -254,7 +276,91 @@ describe("config mutation and control commands", () => {
       },
     ]);
     expect(restartCalls).toHaveLength(0);
-    expect(console_.logs.join("\n")).toContain("Running runtime will reload config shortly.");
+    expect(configReloadRequests).toEqual([{}]);
+    expect(console_.logs.join("\n")).toContain(
+      "Running runtime accepted config reload request.",
+    );
+  });
+
+  test("config mutation warns and keeps durable config when daemon reload notification fails", async () => {
+    const config = defaultConfig();
+    config.sinks = [
+      {
+        id: "postgres-team",
+        type: "postgres",
+        enabled: true,
+        connectionString: "postgresql://localhost:5432/jin",
+      },
+    ];
+    await writeTestConfig(tempDir, config);
+
+    watcherState = {
+      name: "watcher",
+      status: "running",
+      mode: "daemon",
+      pid: 445,
+      lifecycleState: "running",
+    };
+    runtimeStatus = {
+      state: "running",
+      owner: makeOwner("daemon", 445),
+      issues: [],
+    };
+    configReloadResult = {
+      status: "failed",
+      message: "connection refused",
+    };
+
+    await routeAddCommand({
+      remote: "https://github.com/org/alpha.git",
+      sink: "postgres-team",
+    });
+
+    const nextConfig = await readTestConfig(tempDir);
+    expect(nextConfig.routes).toEqual([
+      {
+        match: { remote: "github.com/org/alpha" },
+        sinks: ["postgres-team"],
+      },
+    ]);
+    expect(configReloadRequests).toEqual([{}]);
+    expect(restartCalls).toHaveLength(0);
+    expect(console_.logs.join("\n")).toContain(
+      "WARNING: Config saved, but jin could not notify the running runtime to reload: connection refused",
+    );
+    expect(console_.logs.join("\n")).toContain(
+      "File watcher fallback will try to apply the change; otherwise restart jin.",
+    );
+  });
+
+  test("config mutation keeps next-start behavior when no daemon is running", async () => {
+    const config = defaultConfig();
+    config.sinks = [
+      {
+        id: "postgres-team",
+        type: "postgres",
+        enabled: true,
+        connectionString: "postgresql://localhost:5432/jin",
+      },
+    ];
+    await writeTestConfig(tempDir, config);
+
+    await routeAddCommand({
+      remote: "https://github.com/org/alpha.git",
+      sink: "postgres-team",
+    });
+
+    const nextConfig = await readTestConfig(tempDir);
+    expect(nextConfig.routes).toEqual([
+      {
+        match: { remote: "github.com/org/alpha" },
+        sinks: ["postgres-team"],
+      },
+    ]);
+    expect(configReloadRequests).toEqual([]);
+    expect(console_.logs.join("\n")).toContain(
+      "Changes will apply the next time jin starts.",
+    );
   });
 
   test("sink add refuses duplicate transport endpoints when export identity differs", async () => {
@@ -394,21 +500,61 @@ describe("config mutation and control commands", () => {
 
     let nextConfig = await readTestConfig(tempDir);
     expect(nextConfig.sinks[0].enabled).toBe(false);
+    expect(configReloadRequests).toEqual([{}]);
     expect(restartCalls).toHaveLength(0);
-    expect(markRuntimeRunningCalls[0]?.issues).toEqual([
-      {
-        subsystem: "push",
-        message: "sink paused by operator: postgres-team",
-        paused: true,
-      },
-    ]);
+    expect(markRuntimeRunningCalls).toEqual([]);
+    expect(console_.logs.join("\n")).toContain(
+      "Running runtime accepted config reload request.",
+    );
 
     await sinkEnableCommand("postgres-team");
 
     nextConfig = await readTestConfig(tempDir);
     expect(nextConfig.sinks[0].enabled).toBe(true);
-    expect(markRuntimeRunningCalls.at(-1)?.issues).toEqual([]);
+    expect(configReloadRequests).toEqual([{}, {}]);
+    expect(markRuntimeRunningCalls).toEqual([]);
     expect(restartCalls).toHaveLength(0);
+  });
+
+  test("sink enable and disable --yes perform a controlled restart", async () => {
+    const config = defaultConfig();
+    config.sinks = [
+      {
+        id: "postgres-team",
+        type: "postgres",
+        enabled: true,
+        connectionString: "postgresql://localhost:5432/jin",
+      },
+    ];
+    await writeTestConfig(tempDir, config);
+
+    watcherState = {
+      name: "watcher",
+      status: "running",
+      mode: "service",
+      pid: 516,
+      lifecycleState: "running",
+    };
+    runtimeStatus = {
+      state: "running",
+      owner: makeOwner("service", 516),
+      issues: [],
+    };
+
+    await sinkDisableCommand("postgres-team", { yes: true });
+
+    let nextConfig = await readTestConfig(tempDir);
+    expect(nextConfig.sinks[0].enabled).toBe(false);
+    expect(configReloadRequests).toEqual([]);
+    expect(restartCalls).toEqual([{ service: true }]);
+
+    restartCalls = [];
+    await sinkEnableCommand("postgres-team", { yes: true });
+
+    nextConfig = await readTestConfig(tempDir);
+    expect(nextConfig.sinks[0].enabled).toBe(true);
+    expect(configReloadRequests).toEqual([]);
+    expect(restartCalls).toEqual([{ service: true }]);
   });
 
   test("sink repush resets and replays only the selected sink state", async () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -8,8 +8,10 @@ import {
   DEFAULT_SCAN_INTERVAL_MS,
   DEFAULT_WEBHOOK_TIMEOUT_MS,
   defaultConfig,
+  loadRuntimeConfigGeneration,
   loadStartupConfig,
   normalizeConfig,
+  updateConfig,
 } from "../src/config";
 
 afterEach(() => {
@@ -214,5 +216,187 @@ describe("loadStartupConfig", () => {
     });
     expect(written.adapters["claude-code"]).toEqual({ enabled: true });
     expect(written.adapters.codex).toEqual({ enabled: true });
+  });
+
+  test("rejects invalid existing config on startup instead of normalizing it live", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "jin-config-test-"));
+    process.env.JIN_CONFIG_DIR = dir;
+
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify(
+        {
+          sinks: [
+            {
+              id: "postgres-team",
+              type: "postgres",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    await expect(loadStartupConfig()).rejects.toThrow(
+      "config.sinks[0].connectionString must be a non-empty string",
+    );
+  });
+
+  test("rejects malformed explicit startup sections instead of replacing them", async () => {
+    const cases: Array<{
+      name: string;
+      config: unknown;
+      message: string;
+    }> = [
+      {
+        name: "root",
+        config: [],
+        message: "config root must be an object",
+      },
+      {
+        name: "adapters",
+        config: { adapters: [] },
+        message: "config.adapters must be an object",
+      },
+      {
+        name: "adapter entry",
+        config: { adapters: { cursor: false } },
+        message: "config.adapters.cursor must be an object",
+      },
+      {
+        name: "sinks",
+        config: { sinks: { bad: true } },
+        message: "config.sinks must be an array",
+      },
+      {
+        name: "routes",
+        config: { routes: { bad: true } },
+        message: "config.routes must be an array",
+      },
+      {
+        name: "watch",
+        config: { watch: [] },
+        message: "config.watch must be an object",
+      },
+      {
+        name: "watch poll",
+        config: { watch: { pollIntervalMs: 0 } },
+        message: "config.watch.pollIntervalMs must be a positive integer",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const dir = mkdtempSync(join(tmpdir(), `jin-config-test-${testCase.name}-`));
+      process.env.JIN_CONFIG_DIR = dir;
+      writeFileSync(
+        join(dir, "config.json"),
+        JSON.stringify(testCase.config, null, 2),
+      );
+
+      await expect(loadStartupConfig()).rejects.toThrow(testCase.message);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadRuntimeConfigGeneration", () => {
+  test("rejects invalid sink generations instead of silently dropping them", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "jin-config-test-"));
+    process.env.JIN_CONFIG_DIR = dir;
+
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify(
+        {
+          adapters: {},
+          sinks: [
+            {
+              id: "postgres-team",
+              type: "postgres",
+            },
+          ],
+          routes: [],
+          watch: {
+            pollIntervalMs: 10_000,
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await expect(loadRuntimeConfigGeneration()).rejects.toThrow(
+      "config.sinks[0].connectionString must be a non-empty string",
+    );
+  });
+
+  test("rejects invalid route generations instead of normalizing them empty", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "jin-config-test-"));
+    process.env.JIN_CONFIG_DIR = dir;
+
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify(
+        {
+          sinks: [],
+          routes: [
+            {
+              match: "github.com/acme/*",
+              sinks: ["postgres-team"],
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    await expect(loadRuntimeConfigGeneration()).rejects.toThrow(
+      "config.routes[0].match must be an object",
+    );
+  });
+});
+
+describe("updateConfig", () => {
+  test("refuses to mutate an invalid existing generation", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "jin-config-test-"));
+    process.env.JIN_CONFIG_DIR = dir;
+
+    writeFileSync(
+      join(dir, "config.json"),
+      JSON.stringify(
+        {
+          sinks: [
+            {
+              id: "postgres-team",
+              type: "postgres",
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    await expect(
+      updateConfig((config) => {
+        config.routes.push({
+          match: {},
+          sinks: ["postgres-team"],
+        });
+      }),
+    ).rejects.toThrow(
+      "config.sinks[0].connectionString must be a non-empty string",
+    );
+
+    const persisted = JSON.parse(readFileSync(join(dir, "config.json"), "utf-8"));
+    expect(persisted.sinks).toEqual([
+      {
+        id: "postgres-team",
+        type: "postgres",
+      },
+    ]);
+    expect(persisted.routes).toBeUndefined();
   });
 });

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdtempSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -82,6 +82,10 @@ afterEach(() => {
   exitMock.restore();
   delete process.env.JIN_CONFIG_DIR;
   removeTestDir(tempDir);
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe("jin connect", () => {

--- a/test/lifecycle-boundary.test.ts
+++ b/test/lifecycle-boundary.test.ts
@@ -1,4 +1,5 @@
 import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -126,6 +127,10 @@ beforeEach(() => {
 afterEach(() => {
   console_.restore();
   rmSync(tempDir, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe("lifecycle runtime boundary", () => {

--- a/test/local-control-boundary.test.ts
+++ b/test/local-control-boundary.test.ts
@@ -31,6 +31,9 @@ const {
   getLocalControlStatus,
 } = await import("../src/api/control");
 const { createRoutes, matchRoute } = await import("../src/api/routes");
+const { startLocalApiServer } = await import("../src/api/server");
+const { DESKTOP_AUTH_HEADER } = await import("../src/api/auth");
+const { requestDaemonConfigReload } = await import("../src/api/client");
 
 function makeOwner(mode: "daemon" | "service" | "foreground", pid = 515) {
   return {
@@ -206,6 +209,118 @@ describe("local control boundary", () => {
 
     expect(restartResponse.status).toBe(200);
     expect(actionCalls).toEqual(["start", "restart"]);
+  });
+
+  test("config reload route delegates to the attached pipeline reload callback", async () => {
+    const reloadCalls: string[] = [];
+    const routes = createRoutes({
+      queryStore: fakeQueryStore as any,
+      controlBoundary: createLocalControlBoundary({
+        requestConfigReload: (source) => {
+          reloadCalls.push(source);
+          return true;
+        },
+      }),
+    });
+
+    const route = matchRoute(routes, "POST", "/api/control/config/reload");
+    expect(route).not.toBeNull();
+
+    const response = await route!.handler(
+      new Request("http://localhost/api/control/config/reload", {
+        method: "POST",
+      }),
+      route!.params,
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(202);
+    expect(payload.accepted).toBe(true);
+    expect(payload.message).toBe("Config reload accepted.");
+    expect(reloadCalls).toEqual(["command"]);
+  });
+
+  test("config reload route rejects unauthenticated local API requests", async () => {
+    const reloadCalls: string[] = [];
+    const serveCalls: Array<{
+      fetch: (request: Request) => Promise<Response>;
+    }> = [];
+    const server = startLocalApiServer({
+      authToken: "reload-test-token",
+      platform: "darwin",
+      queryStore: fakeQueryStore as any,
+      socketPath: "/tmp/jin-local-control-boundary.sock",
+      controlBoundary: createLocalControlBoundary({
+        requestConfigReload: (source) => {
+          reloadCalls.push(source);
+          return true;
+        },
+      }),
+      serve: (options) => {
+        serveCalls.push({ fetch: options.fetch });
+        return { stop() {} };
+      },
+    });
+
+    const unauthorizedResponse = await serveCalls[0].fetch(
+      new Request("http://localhost/api/control/config/reload", {
+        method: "POST",
+      }),
+    );
+    expect(unauthorizedResponse.status).toBe(401);
+    expect(reloadCalls).toEqual([]);
+
+    const authorizedResponse = await serveCalls[0].fetch(
+      new Request("http://localhost/api/control/config/reload", {
+        method: "POST",
+        headers: { [DESKTOP_AUTH_HEADER]: "reload-test-token" },
+      }),
+    );
+    const authorizedPayload = await authorizedResponse.json();
+
+    expect(authorizedResponse.status).toBe(202);
+    expect(authorizedPayload.accepted).toBe(true);
+    expect(reloadCalls).toEqual(["command"]);
+
+    server?.stop();
+  });
+
+  test("config reload client posts to the authenticated local Unix socket endpoint", async () => {
+    const requests: Array<{ input: unknown; init: RequestInit & { unix?: string } }> = [];
+
+    const result = await requestDaemonConfigReload({
+      endpoint: "/tmp/jin-reload.sock",
+      token: "client-test-token",
+      timeoutMs: 500,
+      fetch: async (input, init) => {
+        requests.push({
+          input,
+          init: init as RequestInit & { unix?: string },
+        });
+        return new Response(
+          JSON.stringify({
+            accepted: true,
+            message: "Config reload accepted.",
+          }),
+          { status: 202 },
+        );
+      },
+    });
+
+    expect(result).toEqual({
+      status: "accepted",
+      statusCode: 202,
+      message: "Config reload accepted.",
+    });
+    expect(requests).toHaveLength(1);
+    expect(requests[0].input).toBe(
+      "http://localhost/api/control/config/reload",
+    );
+    expect(requests[0].init.method).toBe("POST");
+    expect(requests[0].init.unix).toBe("/tmp/jin-reload.sock");
+    expect(
+      new Headers(requests[0].init.headers).get(DESKTOP_AUTH_HEADER),
+    ).toBe("client-test-token");
   });
 
   test("packaged Desktop lifecycle actions resolve the installed jin CLI from PATH", () => {

--- a/test/local-control-boundary.test.ts
+++ b/test/local-control-boundary.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
 
 let runtimeStatus: any;
 let runtimePaths: any;
@@ -60,6 +60,10 @@ beforeEach(() => {
   components = [
     { name: "watcher", status: "stopped", lifecycleState: "stopped" },
   ];
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe("local control boundary", () => {

--- a/test/pipeline-spine.test.ts
+++ b/test/pipeline-spine.test.ts
@@ -314,13 +314,49 @@ describe("pipeline spine", () => {
     }
   });
 
-  test("stops remaining local push batches when sink config is disabled mid-push", async () => {
+  test("config reload enqueues push so retargeted sinks receive existing backlog", async () => {
+    const store = new InMemoryConversationStore();
+    const sink = new TestSink("secondary");
+    let sinks: Sink[] = [];
+    let routes: RouteConfig[] = [];
+    store.writeBundle(makeBundle("alpha-1", "alpha"));
+    store.writeBundle(makeBundle("alpha-2", "alpha"));
+
+    const handle = await startPipeline({
+      adapterSource: [],
+      store,
+      sinks,
+      routes,
+      getSinks: () => sinks,
+      getRoutes: () => routes,
+      onConfigReload: async () => {
+        sinks = [sink];
+        routes = [{ match: {}, sinks: ["secondary"] }];
+      },
+    });
+
+    try {
+      handle.reloadConfig("command");
+      await handle.waitForIdle();
+
+      expect(sink.pushCalls).toHaveLength(1);
+      expect(sink.pushCalls[0].map((payload) => payload.conversation.id)).toEqual([
+        "alpha-1",
+        "alpha-2",
+      ]);
+      expect(store.conversationsNeedingPush("secondary")).toEqual([]);
+    } finally {
+      await handle.shutdown();
+    }
+  });
+
+  test("stops remaining local push batches when current config disables the sink", async () => {
     const store = new InMemoryConversationStore();
     const sink = new TestSink("primary");
     store.writeBundle(makeBundle("alpha-1", "alpha"));
     store.writeBundle(makeBundle("alpha-2", "alpha"));
     store.writeBundle(makeBundle("alpha-3", "alpha"));
-    let continueChecks = 0;
+    let deliveryChecks = 0;
 
     const handle = await startPipeline({
       adapterSource: [],
@@ -328,10 +364,15 @@ describe("pipeline spine", () => {
       sinks: [sink],
       routes: ROUTE_ALL_TO_PRIMARY,
       pushBatchSize: 1,
-      shouldContinueSinkPush: (sinkId) => {
+      getCurrentDeliverySnapshot: (sinkId) => {
         expect(sinkId).toBe("primary");
-        continueChecks += 1;
-        return continueChecks === 1;
+        deliveryChecks += 1;
+        const enabled = deliveryChecks <= 2;
+        return {
+          generationToken: enabled ? "enabled" : "disabled",
+          sinks: [{ id: "primary", enabled }],
+          routes: ROUTE_ALL_TO_PRIMARY,
+        };
       },
     });
 
@@ -347,7 +388,133 @@ describe("pipeline spine", () => {
         "alpha-2",
         "alpha-3",
       ]);
-      expect(continueChecks).toBeGreaterThanOrEqual(2);
+      expect(deliveryChecks).toBeGreaterThanOrEqual(3);
+    } finally {
+      await handle.shutdown();
+    }
+  });
+
+  test("stops remaining local push batches when current routes no longer target the sink", async () => {
+    const store = new InMemoryConversationStore();
+    const sink = new TestSink("primary");
+    let deliveryChecks = 0;
+    store.writeBundle(makeBundle("alpha-1", "alpha"));
+    store.writeBundle(makeBundle("alpha-2", "alpha"));
+    store.writeBundle(makeBundle("alpha-3", "alpha"));
+
+    const handle = await startPipeline({
+      adapterSource: [],
+      store,
+      sinks: [sink],
+      routes: ROUTE_ALL_TO_PRIMARY,
+      pushBatchSize: 1,
+      getCurrentDeliverySnapshot: () => {
+        deliveryChecks += 1;
+        const routes = deliveryChecks <= 2 ? ROUTE_ALL_TO_PRIMARY : [];
+        return {
+          generationToken: routes.length > 0 ? "routed" : "unrouted",
+          sinks: [{ id: "primary", enabled: true }],
+          routes,
+        };
+      },
+    });
+
+    try {
+      handle.enqueue({ kind: "push" });
+      await handle.waitForIdle();
+
+      expect(sink.pushCalls).toHaveLength(1);
+      expect(sink.pushCalls[0].map((payload) => payload.conversation.id)).toEqual([
+        "alpha-1",
+      ]);
+      expect(store.conversationsNeedingPush("primary")).toEqual([
+        "alpha-2",
+        "alpha-3",
+      ]);
+      expect(deliveryChecks).toBeGreaterThanOrEqual(3);
+    } finally {
+      await handle.shutdown();
+    }
+  });
+
+  test("stops remaining local push batches when current config removes the sink", async () => {
+    const store = new InMemoryConversationStore();
+    const sink = new TestSink("primary");
+    let deliveryChecks = 0;
+    store.writeBundle(makeBundle("alpha-1", "alpha"));
+    store.writeBundle(makeBundle("alpha-2", "alpha"));
+
+    const handle = await startPipeline({
+      adapterSource: [],
+      store,
+      sinks: [sink],
+      routes: ROUTE_ALL_TO_PRIMARY,
+      pushBatchSize: 1,
+      getCurrentDeliverySnapshot: () => {
+        deliveryChecks += 1;
+        const sinkPresent = deliveryChecks <= 2;
+        return {
+          generationToken: sinkPresent ? "present" : "removed",
+          sinks: sinkPresent ? [{ id: "primary", enabled: true }] : [],
+          routes: ROUTE_ALL_TO_PRIMARY,
+        };
+      },
+    });
+
+    try {
+      handle.enqueue({ kind: "push" });
+      await handle.waitForIdle();
+
+      expect(sink.pushCalls).toHaveLength(1);
+      expect(sink.pushCalls[0].map((payload) => payload.conversation.id)).toEqual([
+        "alpha-1",
+      ]);
+      expect(store.conversationsNeedingPush("primary")).toEqual(["alpha-2"]);
+      expect(deliveryChecks).toBeGreaterThanOrEqual(3);
+    } finally {
+      await handle.shutdown();
+    }
+  });
+
+  test("does not record push success when config changes during an in-flight batch", async () => {
+    const store = new InMemoryConversationStore();
+    const pushStarted = deferred<void>();
+    const finishPush = deferred<void>();
+    const sink = new TestSink("primary");
+    let generationToken = "before";
+    store.writeBundle(makeBundle("alpha-1", "alpha"));
+
+    sink.pushImpl = async (payloads) => {
+      pushStarted.resolve();
+      await finishPush.promise;
+      return {
+        pushed: payloads.length,
+        failed: 0,
+        errors: [],
+      };
+    };
+
+    const handle = await startPipeline({
+      adapterSource: [],
+      store,
+      sinks: [sink],
+      routes: ROUTE_ALL_TO_PRIMARY,
+      getCurrentDeliverySnapshot: () => ({
+        generationToken,
+        sinks: [{ id: "primary", enabled: true }],
+        routes: ROUTE_ALL_TO_PRIMARY,
+      }),
+    });
+
+    try {
+      handle.enqueue({ kind: "push" });
+      await pushStarted.promise;
+      generationToken = "after";
+      finishPush.resolve();
+      await handle.waitForIdle();
+
+      expect(sink.pushCalls).toHaveLength(1);
+      expect(store.conversationsNeedingPush("primary")).toEqual(["alpha-1"]);
     } finally {
       await handle.shutdown();
     }
@@ -543,6 +710,7 @@ class TestSink implements Sink {
   readonly name: string;
   readonly pushCalls: PushPayload[][] = [];
   closeCalls = 0;
+  pushImpl?: (payloads: PushPayload[]) => Promise<PushResult>;
 
   constructor(readonly id: string) {
     this.name = id;
@@ -550,11 +718,14 @@ class TestSink implements Sink {
 
   async push(payloads: PushPayload[]): Promise<PushResult> {
     this.pushCalls.push(clonePayloads(payloads));
-    return {
-      pushed: payloads.length,
-      failed: 0,
-      errors: [],
-    };
+    const result = this.pushImpl
+      ? await this.pushImpl(payloads)
+      : {
+          pushed: payloads.length,
+          failed: 0,
+          errors: [],
+        };
+    return result;
   }
 
   async healthCheck() {

--- a/test/pipeline-spine.test.ts
+++ b/test/pipeline-spine.test.ts
@@ -265,6 +265,55 @@ describe("pipeline spine", () => {
     }
   });
 
+  test("prioritizes config reload ahead of queued push work and uses refreshed routes", async () => {
+    const store = new InMemoryConversationStore();
+    const sink = new TestSink("primary");
+    const firstFindChanged = deferred<void>();
+    let routes: RouteConfig[] = [];
+    const alpha = new TestAdapter("alpha", {
+      async findChanged() {
+        await firstFindChanged.promise;
+        return [makeRef("alpha-1", "alpha")];
+      },
+      async loadConversation(ref) {
+        return makeBundle(ref.id, "alpha");
+      },
+    });
+
+    const handle = await startPipeline({
+      adapterSource: [alpha],
+      store,
+      sinks: [sink],
+      routes,
+      getRoutes: () => routes,
+      onConfigReload: async () => {
+        routes = ROUTE_ALL_TO_PRIMARY;
+      },
+    });
+
+    try {
+      handle.enqueue({
+        kind: "ingest-adapter",
+        adapterId: "alpha",
+        hint: { kind: "startup-scan" },
+      });
+
+      await waitFor(() => alpha.findChangedHints.length === 1);
+      handle.enqueue({ kind: "push" });
+      handle.reloadConfig("command");
+
+      firstFindChanged.resolve();
+      await handle.waitForIdle();
+
+      expect(sink.pushCalls).toHaveLength(1);
+      expect(
+        sink.pushCalls[0].map((payload) => payload.conversation.id),
+      ).toEqual(["alpha-1"]);
+    } finally {
+      await handle.shutdown();
+    }
+  });
+
   test("shutdown skips queued normal work and performs one bounded final flush", async () => {
     const store = new InMemoryConversationStore();
     const sink = new TestSink("primary");

--- a/test/pipeline-spine.test.ts
+++ b/test/pipeline-spine.test.ts
@@ -314,6 +314,79 @@ describe("pipeline spine", () => {
     }
   });
 
+  test("stops remaining local push batches when sink config is disabled mid-push", async () => {
+    const store = new InMemoryConversationStore();
+    const sink = new TestSink("primary");
+    store.writeBundle(makeBundle("alpha-1", "alpha"));
+    store.writeBundle(makeBundle("alpha-2", "alpha"));
+    store.writeBundle(makeBundle("alpha-3", "alpha"));
+    let continueChecks = 0;
+
+    const handle = await startPipeline({
+      adapterSource: [],
+      store,
+      sinks: [sink],
+      routes: ROUTE_ALL_TO_PRIMARY,
+      pushBatchSize: 1,
+      shouldContinueSinkPush: (sinkId) => {
+        expect(sinkId).toBe("primary");
+        continueChecks += 1;
+        return continueChecks === 1;
+      },
+    });
+
+    try {
+      handle.enqueue({ kind: "push" });
+      await handle.waitForIdle();
+
+      expect(sink.pushCalls).toHaveLength(1);
+      expect(sink.pushCalls[0].map((payload) => payload.conversation.id)).toEqual([
+        "alpha-1",
+      ]);
+      expect(store.conversationsNeedingPush("primary")).toEqual([
+        "alpha-2",
+        "alpha-3",
+      ]);
+      expect(continueChecks).toBeGreaterThanOrEqual(2);
+    } finally {
+      await handle.shutdown();
+    }
+  });
+
+  test("fatal config reload stops without shutdown flushing stale sink routes", async () => {
+    const store = new InMemoryConversationStore();
+    const sink = new TestSink("primary");
+    store.writeBundle(makeBundle("alpha-1", "alpha"));
+    const reloadStarted = deferred<void>();
+    const finishReload = deferred<void>();
+    const reloadCompleted = deferred<void>();
+
+    const handle = await startPipeline({
+      adapterSource: [],
+      store,
+      sinks: [sink],
+      routes: ROUTE_ALL_TO_PRIMARY,
+      onConfigReload: async () => {
+        reloadStarted.resolve();
+        await finishReload.promise;
+        reloadCompleted.resolve();
+        return false;
+      },
+    });
+
+    handle.reloadConfig("command");
+    await reloadStarted.promise;
+    handle.enqueue({ kind: "push" });
+    finishReload.resolve();
+    await reloadCompleted.promise;
+
+    const result = await handle.shutdown();
+
+    expect(result.timedOut).toBe(false);
+    expect(sink.pushCalls).toHaveLength(0);
+    expect(store.conversationsNeedingPush("primary")).toEqual(["alpha-1"]);
+  });
+
   test("shutdown skips queued normal work and performs one bounded final flush", async () => {
     const store = new InMemoryConversationStore();
     const sink = new TestSink("primary");

--- a/test/poisoned-local-store-recovery.test.ts
+++ b/test/poisoned-local-store-recovery.test.ts
@@ -1,4 +1,5 @@
 import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -111,6 +112,10 @@ afterEach(() => {
   exitMock?.restore();
   exitMock = null;
   rmSync(tempDir, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe("W3-RECOVERY-01 poisoned local store recovery guidance", () => {

--- a/test/runtime-store-cutover.test.ts
+++ b/test/runtime-store-cutover.test.ts
@@ -1,4 +1,5 @@
 import {
+  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -75,6 +76,7 @@ mock.module("../src/pipeline/loop", () => ({
 }));
 
 mock.module("../src/updater", () => ({
+  VERSION: "0.0.0-test",
   checkForUpdate: async () => null,
 }));
 
@@ -139,6 +141,10 @@ afterEach(() => {
   delete process.env.JIN_RSS_WARNING_MB;
   delete process.env.JIN_RSS_HARD_LIMIT_MB;
   rmSync(tempDir, { recursive: true, force: true });
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 describe("W3-RUNTIME-01 live cutover", () => {

--- a/test/team-bootstrap.test.ts
+++ b/test/team-bootstrap.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { afterAll, describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { join } from "path";
 import { createFakeSink } from "./helpers";
 
@@ -94,6 +94,10 @@ afterEach(() => {
   console_.restore();
   exitMock.restore();
   env.cleanup();
+});
+
+afterAll(() => {
+  mock.restore();
 });
 
 // ── jin team bridge (was team-config) ───────────────────────────────────


### PR DESCRIPTION
## Summary

- routes config-mutating CLI commands through durable config writes plus daemon local API reload notification
- hardens startup/reload config generation validation so malformed explicit sections are rejected instead of normalized away
- adds pipeline safeguards for fatal reload shutdown and sink-disable batch-boundary interruption
- records W4-CONFIG-01/W4-CONFIG-02 execution packets and BP-08 contract updates

## Validation

- `bun run typecheck`
- `bun test test/config.test.ts test/config-mutation-control.test.ts test/local-control-boundary.test.ts test/pipeline-spine.test.ts test/cli-surface-cleanup.test.ts`
- `bun run test:release-gates`
- `bun run build`
- `git diff --check`

## Notes

- W4-CONFIG-01 BP/contract and code/test rechecks passed.
- Active sink disable interrupts at local push batch boundaries; an already in-flight `sink.push()` call is not aborted.
- W4-CONFIG-02 remains queued for reload/queue completion status visibility.
