### PR TITLE
Make daemon debug JSONL opt in

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 - If a fix needs behavior that conflicts with a frozen blueprint or contract, stop and surface the drift explicitly before implementing it. Do not hide contract extensions behind duck-typed hooks or packet-local shortcuts.
 - Do not add standalone `.mmd` copies of Mermaid diagrams unless they are generated from a current source-of-truth doc or explicitly owned as first-class artifacts.
 - Daemon diagnostic JSONL must stay explicitly opt-in and hidden from help text; default daemon runs should rely on bounded logs/status, not `debug.jsonl`.
+- Policy-like behavior must have one owner module and tests at the policy boundary. Do not scatter env-var checks, magic flag strings, default paths, schema names, or compatibility decisions across call sites.
 - Prefer small, typed changes to existing files.
 - Run focused validation after changes when practical.
 - Prefer `bun run test` over raw `bun test` for broad local validation. The repo runner isolates each `.test.ts` file in a fresh Bun process so top-level `mock.module()` calls cannot leak across files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - Desktop release matrices, package-script target guards, and `jin desktop` asset candidates must describe the same platform/architecture set.
 - If a fix needs behavior that conflicts with a frozen blueprint or contract, stop and surface the drift explicitly before implementing it. Do not hide contract extensions behind duck-typed hooks or packet-local shortcuts.
 - Do not add standalone `.mmd` copies of Mermaid diagrams unless they are generated from a current source-of-truth doc or explicitly owned as first-class artifacts.
+- Daemon diagnostic JSONL must stay explicitly opt-in and hidden from help text; default daemon runs should rely on bounded logs/status, not `debug.jsonl`.
 - Prefer small, typed changes to existing files.
 - Run focused validation after changes when practical.
 - Prefer `bun run test` over raw `bun test` for broad local validation. The repo runner isolates each `.test.ts` file in a fresh Bun process so top-level `mock.module()` calls cannot leak across files.

--- a/docs/solutions/2026-05-21-daemon-debug-jsonl-is-opt-in.md
+++ b/docs/solutions/2026-05-21-daemon-debug-jsonl-is-opt-in.md
@@ -1,0 +1,54 @@
+---
+title: Daemon debug JSONL must be opt-in
+date: 2026-05-21
+tags: [daemon, pipeline, diagnostics, config]
+related: [BP-07, BP-11]
+---
+
+# Daemon debug JSONL must be opt-in
+
+## Problem
+
+The long-lived daemon wrote structured diagnostic events to
+`~/.config/jin/debug.jsonl` by default. Because the file was append-only and
+fed by startup detection, pipeline work, and local API diagnostics, a normal
+foreground daemon run could silently grow the file into tens of gigabytes.
+
+## Solution
+
+Gate daemon diagnostic JSONL behind a hidden startup option. Normal
+`jin start`, `jin start --foreground`, service launches, and restarts now pass
+no diagnostic log path into adapter detection, the pipeline, or the local API
+server. When diagnostics are needed, the same path can still be enabled
+explicitly and `JIN_DIAGNOSTIC_LOG` remains a path override under that opt-in.
+
+## Key Insight
+
+Long-lived developer daemons need bounded default observability. Append-only
+diagnostic streams are useful during investigations, but they must require an
+operator opt-in and should not appear in normal help text as a supported daily
+surface.
+
+## Prevention
+
+Test the daemon command path both with and without the diagnostic opt-in. The
+default path should assert that no `debug.jsonl` is created even when
+`JIN_DIAGNOSTIC_LOG` is set, while the opt-in path should assert that the
+diagnostic path reaches adapter detection, the pipeline, and the local API
+server.
+
+## Related
+
+- BP-07: process lifecycle and runtime ownership
+- BP-11: bounded local diagnostics across the Desktop daemon boundary
+
+## Files Changed
+
+- `src/index.ts`
+- `src/commands/watch.ts`
+- `src/commands/start.ts`
+- `src/commands/service.ts`
+- `src/daemon/daemonize.ts`
+- `test/runtime-store-cutover.test.ts`
+- `test/cli-surface-cleanup.test.ts`
+- `test/acceptance/verify.ts`

--- a/docs/solutions/2026-05-21-daemon-debug-jsonl-is-opt-in.md
+++ b/docs/solutions/2026-05-21-daemon-debug-jsonl-is-opt-in.md
@@ -16,11 +16,12 @@ foreground daemon run could silently grow the file into tens of gigabytes.
 
 ## Solution
 
-Gate daemon diagnostic JSONL behind a hidden startup option. Normal
-`jin start`, `jin start --foreground`, service launches, and restarts now pass
-no diagnostic log path into adapter detection, the pipeline, or the local API
-server. When diagnostics are needed, the same path can still be enabled
-explicitly and `JIN_DIAGNOSTIC_LOG` remains a path override under that opt-in.
+Gate diagnostic JSONL behind a hidden startup option and resolve that policy in
+one module. Normal `jin start`, `jin start --foreground`, service launches,
+restarts, and `jin sink repush` pass no diagnostic log path into adapter
+detection, the pipeline, or the local API server. When diagnostics are needed,
+the same path can still be enabled explicitly and `JIN_DIAGNOSTIC_LOG` remains
+a path override under that opt-in.
 
 ## Key Insight
 
@@ -29,13 +30,25 @@ diagnostic streams are useful during investigations, but they must require an
 operator opt-in and should not appear in normal help text as a supported daily
 surface.
 
+The opt-in policy itself must be owned centrally. A scattered fix that updates
+only the first command path is fragile: every future caller has to remember that
+`JIN_DIAGNOSTIC_LOG` is not an enable switch and that `debug.jsonl` is not a
+default runtime artifact. Centralizing the policy makes the intended behavior a
+small API instead of a convention.
+
 ## Prevention
 
-Test the daemon command path both with and without the diagnostic opt-in. The
-default path should assert that no `debug.jsonl` is created even when
+Test both the policy boundary and command paths. The policy test should assert
+that `JIN_DIAGNOSTIC_LOG` is a path override, not an enable switch. The default
+command path should assert that no `debug.jsonl` is created even when
 `JIN_DIAGNOSTIC_LOG` is set, while the opt-in path should assert that the
 diagnostic path reaches adapter detection, the pipeline, and the local API
 server.
+
+During review, search for direct `debug.jsonl` path construction,
+`JIN_DIAGNOSTIC_LOG` reads, and `DiagnosticLogger` construction. Production
+commands should go through the central debug JSONL policy; lower-level
+diagnostic utilities may still write when an already-resolved path is passed in.
 
 ## Related
 
@@ -45,10 +58,14 @@ server.
 ## Files Changed
 
 - `src/index.ts`
+- `src/diagnostics/debug-jsonl.ts`
 - `src/commands/watch.ts`
 - `src/commands/start.ts`
 - `src/commands/service.ts`
+- `src/commands/sink.ts`
 - `src/daemon/daemonize.ts`
+- `test/debug-jsonl-policy.test.ts`
 - `test/runtime-store-cutover.test.ts`
+- `test/config-mutation-control.test.ts`
 - `test/cli-surface-cleanup.test.ts`
 - `test/acceptance/verify.ts`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jin",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "license": "FSL-1.1-ALv2",
   "type": "module",
   "bin": {

--- a/src/commands/service.ts
+++ b/src/commands/service.ts
@@ -14,6 +14,7 @@ import {
   windowsTaskIdentityPowerShellLines,
   windowsTaskReferenceForDocs,
 } from "../windows-task";
+import { WRITE_DEBUG_JSONL_FLAG } from "../diagnostics/debug-jsonl";
 
 const PLATFORM = process.platform;
 const HOME = process.env.HOME || process.env.USERPROFILE || "";
@@ -26,7 +27,7 @@ function serviceStartArgs(opts: ServiceInstallOptions = {}): string[] {
   return [
     "start",
     "--foreground",
-    ...(opts.writeDebugJsonl ? ["--write-debug-jsonl"] : []),
+    ...(opts.writeDebugJsonl ? [`--${WRITE_DEBUG_JSONL_FLAG}`] : []),
   ];
 }
 
@@ -173,7 +174,7 @@ const LAUNCHD_PLIST = join(LAUNCHD_DIR, "com.jin.agent.plist");
 function launchdPlist(binPath: string, opts: ServiceInstallOptions = {}): string {
   const logDir = join(HOME, "Library", "Logs");
   const extraArgs = opts.writeDebugJsonl
-    ? "        <string>--write-debug-jsonl</string>\n"
+    ? `        <string>--${WRITE_DEBUG_JSONL_FLAG}</string>\n`
     : "";
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"

--- a/src/commands/service.ts
+++ b/src/commands/service.ts
@@ -18,6 +18,18 @@ import {
 const PLATFORM = process.platform;
 const HOME = process.env.HOME || process.env.USERPROFILE || "";
 
+interface ServiceInstallOptions {
+  writeDebugJsonl?: boolean;
+}
+
+function serviceStartArgs(opts: ServiceInstallOptions = {}): string[] {
+  return [
+    "start",
+    "--foreground",
+    ...(opts.writeDebugJsonl ? ["--write-debug-jsonl"] : []),
+  ];
+}
+
 function getJinBinaryPath(): string {
   // For compiled binary, resolve real path
   try {
@@ -56,7 +68,8 @@ function getJinBinaryPath(): string {
 const SYSTEMD_DIR = join(HOME, ".config", "systemd", "user");
 const SYSTEMD_UNIT = join(SYSTEMD_DIR, "jin.service");
 
-function systemdUnit(binPath: string): string {
+function systemdUnit(binPath: string, opts: ServiceInstallOptions = {}): string {
+  const args = serviceStartArgs(opts).join(" ");
   return `[Unit]
 Description=jin — conversation data pipeline for agentic coding tools
 After=network-online.target
@@ -65,7 +78,7 @@ Wants=network-online.target
 [Service]
 Type=simple
 Environment=JIN_LAUNCHED_BY_SERVICE=1
-ExecStart=${binPath} start --foreground
+ExecStart=${binPath} ${args}
 Restart=on-failure
 RestartSec=5s
 StandardOutput=append:${join(configDir(), "jin.log")}
@@ -81,7 +94,7 @@ WantedBy=default.target
 `;
 }
 
-async function linuxInstall(): Promise<void> {
+async function linuxInstall(opts: ServiceInstallOptions = {}): Promise<void> {
   const binPath = getJinBinaryPath();
   console.log(`  Binary: ${binPath}`);
 
@@ -89,7 +102,7 @@ async function linuxInstall(): Promise<void> {
     mkdirSync(SYSTEMD_DIR, { recursive: true });
   }
 
-  writeFileSync(SYSTEMD_UNIT, systemdUnit(binPath));
+  writeFileSync(SYSTEMD_UNIT, systemdUnit(binPath, opts));
   console.log(`  Wrote ${SYSTEMD_UNIT}`);
 
   // Reload, enable, start
@@ -157,8 +170,11 @@ async function linuxStatus(): Promise<void> {
 const LAUNCHD_DIR = join(HOME, "Library", "LaunchAgents");
 const LAUNCHD_PLIST = join(LAUNCHD_DIR, "com.jin.agent.plist");
 
-function launchdPlist(binPath: string): string {
+function launchdPlist(binPath: string, opts: ServiceInstallOptions = {}): string {
   const logDir = join(HOME, "Library", "Logs");
+  const extraArgs = opts.writeDebugJsonl
+    ? "        <string>--write-debug-jsonl</string>\n"
+    : "";
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -172,6 +188,7 @@ function launchdPlist(binPath: string): string {
         <string>${binPath}</string>
         <string>start</string>
         <string>--foreground</string>
+${extraArgs}
     </array>
 
     <key>RunAtLoad</key>
@@ -211,7 +228,7 @@ function launchdPlist(binPath: string): string {
 `;
 }
 
-async function darwinInstall(): Promise<void> {
+async function darwinInstall(opts: ServiceInstallOptions = {}): Promise<void> {
   const binPath = getJinBinaryPath();
   console.log(`  Binary: ${binPath}`);
 
@@ -219,7 +236,7 @@ async function darwinInstall(): Promise<void> {
     mkdirSync(LAUNCHD_DIR, { recursive: true });
   }
 
-  writeFileSync(LAUNCHD_PLIST, launchdPlist(binPath));
+  writeFileSync(LAUNCHD_PLIST, launchdPlist(binPath, opts));
   console.log(`  Wrote ${LAUNCHD_PLIST}`);
 
   // Load the agent
@@ -302,8 +319,9 @@ async function darwinStatus(): Promise<void> {
 
 // ── Windows: Task Scheduler ──────────────────────────────────────────
 
-async function windowsInstall(): Promise<void> {
+async function windowsInstall(opts: ServiceInstallOptions = {}): Promise<void> {
   const binPath = getJinBinaryPath();
+  const args = serviceStartArgs(opts).join(" ");
   console.log(`  Binary: ${binPath}`);
 
   // Register a per-user task so installation doesn't require admin rights.
@@ -319,7 +337,7 @@ async function windowsInstall(): Promise<void> {
     `$schedule = New-Object -ComObject 'Schedule.Service'`,
     `$schedule.Connect()`,
     `try { $null = $schedule.GetFolder($taskPath) } catch { $null = $schedule.GetFolder('\\').CreateFolder('${WINDOWS_TASK_FOLDER_NAME}') }`,
-    `$action = New-ScheduledTaskAction -Execute '${binPath}' -Argument 'start --foreground'`,
+    `$action = New-ScheduledTaskAction -Execute '${binPath}' -Argument '${args}'`,
     `$trigger = New-ScheduledTaskTrigger -AtLogOn -User $me`,
     `$principal = New-ScheduledTaskPrincipal -UserId $me -LogonType Interactive -RunLevel Limited`,
     `$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -RestartCount 3 -RestartInterval (New-TimeSpan -Minutes 1)`,
@@ -415,7 +433,10 @@ async function stopExistingRuntimeForServiceInstall(): Promise<boolean> {
   return true;
 }
 
-export async function serviceCommand(action: string | undefined): Promise<void> {
+export async function serviceCommand(
+  action: string | undefined,
+  opts: ServiceInstallOptions = {},
+): Promise<void> {
   console.log(`\n  jin service — ${PLATFORM}\n`);
 
   switch (action) {
@@ -427,9 +448,9 @@ export async function serviceCommand(action: string | undefined): Promise<void> 
 
       markRuntimeStarting("service");
 
-      if (PLATFORM === "linux") await linuxInstall();
-      else if (PLATFORM === "darwin") await darwinInstall();
-      else if (PLATFORM === "win32") await windowsInstall();
+      if (PLATFORM === "linux") await linuxInstall(opts);
+      else if (PLATFORM === "darwin") await darwinInstall(opts);
+      else if (PLATFORM === "win32") await windowsInstall(opts);
       else console.log(`  Unsupported platform: ${PLATFORM}`);
 
       await Bun.sleep(250);

--- a/src/commands/sink.ts
+++ b/src/commands/sink.ts
@@ -43,6 +43,7 @@ export interface SinkCommandOptions {
   teamId?: string;
   userId?: string;
   restart?: boolean;
+  writeDebugJsonl?: boolean;
 }
 
 export interface SinkCandidateInput extends SinkCommandOptions {
@@ -132,7 +133,10 @@ export async function sinkEnableCommand(
   await setSinkEnabled(sinkId, true, opts);
 }
 
-export async function sinkRepushCommand(sinkId: string): Promise<void> {
+export async function sinkRepushCommand(
+  sinkId: string,
+  opts: { writeDebugJsonl?: boolean } = {},
+): Promise<void> {
   if (!sinkId) {
     fail("specify a sink id");
   }
@@ -169,18 +173,21 @@ export async function sinkRepushCommand(sinkId: string): Promise<void> {
     const sinkEnabled = sinkConfig.enabled === undefined ? true : sinkConfig.enabled;
     sink.enabled = sinkEnabled;
 
-    const diagnosticPath =
-      process.env.JIN_DIAGNOSTIC_LOG ||
-      join(runtimePaths.configDir, "debug.jsonl");
-    const diag = new DiagnosticLogger({
-      path: diagnosticPath,
-      getRssBytes: () => process.memoryUsage().rss,
-      getQueueSize: () => 0,
-      getQueueSnapshot: () => [],
-    });
+    const diagnosticPath = opts.writeDebugJsonl
+      ? process.env.JIN_DIAGNOSTIC_LOG ||
+        join(runtimePaths.configDir, "debug.jsonl")
+      : undefined;
+    const diag = diagnosticPath
+      ? new DiagnosticLogger({
+          path: diagnosticPath,
+          getRssBytes: () => process.memoryUsage().rss,
+          getQueueSize: () => 0,
+          getQueueSnapshot: () => [],
+        })
+      : null;
 
     const reset = resetPushStateForSink(store.database, sinkId);
-    diag.repushReset({
+    diag?.repushReset({
       sinkId,
       clearedStateRows: reset.clearedStateRows,
       dirtyBefore: reset.dirtyBefore,
@@ -207,7 +214,7 @@ export async function sinkRepushCommand(sinkId: string): Promise<void> {
       diag,
       reason: "repush",
     });
-    diag.pushResult(
+    diag?.pushResult(
       summary,
       performance.now() - startedAt,
       summary.sinkBreakdown,

--- a/src/commands/sink.ts
+++ b/src/commands/sink.ts
@@ -20,12 +20,12 @@ import {
   getRuntimeStatus,
   runModeLabel,
 } from "../daemon/runtime-state";
+import { resolveDebugJsonlPath } from "../diagnostics/debug-jsonl";
 import { DiagnosticLogger } from "../pipeline/diagnostic";
 import { pushDirty } from "../pipeline/push";
 import type { PipelineLogger } from "../pipeline/types";
 import { createSink } from "../sinks/registry";
 import { finalizeConfigChange } from "./config-control";
-import { join } from "path";
 
 export interface SinkCommandOptions {
   id?: string;
@@ -173,10 +173,10 @@ export async function sinkRepushCommand(
     const sinkEnabled = sinkConfig.enabled === undefined ? true : sinkConfig.enabled;
     sink.enabled = sinkEnabled;
 
-    const diagnosticPath = opts.writeDebugJsonl
-      ? process.env.JIN_DIAGNOSTIC_LOG ||
-        join(runtimePaths.configDir, "debug.jsonl")
-      : undefined;
+    const diagnosticPath = resolveDebugJsonlPath({
+      enabled: opts.writeDebugJsonl,
+      configDir: runtimePaths.configDir,
+    });
     const diag = diagnosticPath
       ? new DiagnosticLogger({
           path: diagnosticPath,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -17,6 +17,7 @@ import {
 
 export async function startCommand(opts: {
   service?: boolean;
+  writeDebugJsonl?: boolean;
 }): Promise<void> {
   const watcherState = getWatcherState();
   const runtimePaths = getRuntimePaths();
@@ -47,7 +48,7 @@ export async function startCommand(opts: {
     }
 
     const { serviceCommand } = await import("./service");
-    await serviceCommand("install");
+    await serviceCommand("install", { writeDebugJsonl: opts.writeDebugJsonl });
     return;
   }
 
@@ -72,7 +73,10 @@ export async function startCommand(opts: {
     markRuntimeStarting("daemon");
     const { watchCommand } = await import("./watch");
     try {
-      await watchCommand({ daemon: true });
+      await watchCommand({
+        daemon: true,
+        writeDebugJsonl: opts.writeDebugJsonl,
+      });
       markRuntimeRunning("daemon");
     } catch (error) {
       clearRuntimeState();
@@ -88,6 +92,7 @@ export async function startCommand(opts: {
 
 export async function restartCommand(opts: {
   service?: boolean;
+  writeDebugJsonl?: boolean;
 }): Promise<void> {
   const watcherState = getWatcherState();
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -36,7 +36,10 @@ import { resolveSelfCommand } from "../runtime/self-command";
 type RuntimeLog = (message: string) => void;
 const CONFIG_RELOAD_WATCH_DEBOUNCE_MS = 150;
 
-export async function watchCommand(opts: { daemon?: boolean }): Promise<void> {
+export async function watchCommand(opts: {
+  daemon?: boolean;
+  writeDebugJsonl?: boolean;
+}): Promise<void> {
   const {
     getRuntimeStatus,
     getRuntimePaths,
@@ -68,7 +71,7 @@ export async function watchCommand(opts: { daemon?: boolean }): Promise<void> {
       console.log("  Note: OS service is installed but not active.");
       console.log("  Consider `jin start --service` instead.\n");
     }
-    return daemonize();
+    return daemonize({ writeDebugJsonl: opts.writeDebugJsonl });
   }
 
   // Foreground mode: error if daemon is already running.
@@ -82,8 +85,9 @@ export async function watchCommand(opts: { daemon?: boolean }): Promise<void> {
   const config = await loadStartupConfig();
   const protectedSourceNotices = protectedSourceStartupNotices(config.adapters);
   const log = createRuntimeLogger(!!process.env.JIN_DAEMON);
-  const diagnosticPath =
-    process.env.JIN_DIAGNOSTIC_LOG || join(configDir(), "debug.jsonl");
+  const diagnosticPath = opts.writeDebugJsonl
+    ? process.env.JIN_DIAGNOSTIC_LOG || join(configDir(), "debug.jsonl")
+    : undefined;
   const sinks = await createActiveSinks(config, log);
   const activeAdapters = await detectActiveAdapters(config, diagnosticPath);
 
@@ -174,7 +178,7 @@ async function startPipeline(
   sinks: V2Sink[],
   log: RuntimeLog,
   initialAdapters: V2Adapter[],
-  diagnosticPath: string,
+  diagnosticPath?: string,
 ): Promise<PipelineHandle> {
   let currentConfig = config;
   let currentSinks = sinks;

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -17,6 +17,7 @@ import { SqliteDiscoveryCache } from "../db/discovery-cache";
 import { openStoreAtPath, type SqliteConversationStore } from "../db/store";
 import { daemonize } from "../daemon/daemonize";
 import { appendDiagnosticEvent } from "../pipeline/diagnostic";
+import { resolveDebugJsonlPath } from "../diagnostics/debug-jsonl";
 import { runPipeline } from "../pipeline/loop";
 import type { PushDeliverySnapshot } from "../pipeline/push";
 import type { PipelineHandle, PipelineLogger } from "../pipeline/types";
@@ -85,9 +86,9 @@ export async function watchCommand(opts: {
   const config = await loadStartupConfig();
   const protectedSourceNotices = protectedSourceStartupNotices(config.adapters);
   const log = createRuntimeLogger(!!process.env.JIN_DAEMON);
-  const diagnosticPath = opts.writeDebugJsonl
-    ? process.env.JIN_DIAGNOSTIC_LOG || join(configDir(), "debug.jsonl")
-    : undefined;
+  const diagnosticPath = resolveDebugJsonlPath({
+    enabled: opts.writeDebugJsonl,
+  });
   const sinks = await createActiveSinks(config, log);
   const activeAdapters = await detectActiveAdapters(config, diagnosticPath);
 

--- a/src/daemon/daemonize.ts
+++ b/src/daemon/daemonize.ts
@@ -6,8 +6,15 @@ import { resolveSelfCommand } from "../runtime/self-command";
 const PID_FILE = join(configDir(), "jin.pid");
 const LOG_FILE = join(configDir(), "jin.log");
 
-export async function daemonize(): Promise<void> {
-  const cmd = [...resolveSelfCommand(), "start", "--foreground"];
+export async function daemonize(opts: {
+  writeDebugJsonl?: boolean;
+} = {}): Promise<void> {
+  const cmd = [
+    ...resolveSelfCommand(),
+    "start",
+    "--foreground",
+    ...(opts.writeDebugJsonl ? ["--write-debug-jsonl"] : []),
+  ];
 
   const logFd = openSync(LOG_FILE, "a");
   const proc = Bun.spawn(cmd, {

--- a/src/daemon/daemonize.ts
+++ b/src/daemon/daemonize.ts
@@ -1,6 +1,7 @@
 import { closeSync, openSync, writeFileSync } from "fs";
 import { join } from "path";
 import { configDir } from "../config";
+import { WRITE_DEBUG_JSONL_FLAG } from "../diagnostics/debug-jsonl";
 import { resolveSelfCommand } from "../runtime/self-command";
 
 const PID_FILE = join(configDir(), "jin.pid");
@@ -13,7 +14,7 @@ export async function daemonize(opts: {
     ...resolveSelfCommand(),
     "start",
     "--foreground",
-    ...(opts.writeDebugJsonl ? ["--write-debug-jsonl"] : []),
+    ...(opts.writeDebugJsonl ? [`--${WRITE_DEBUG_JSONL_FLAG}`] : []),
   ];
 
   const logFd = openSync(LOG_FILE, "a");

--- a/src/diagnostics/debug-jsonl.ts
+++ b/src/diagnostics/debug-jsonl.ts
@@ -1,0 +1,24 @@
+import { join } from "path";
+import { configDir as defaultConfigDir } from "../config";
+
+export const WRITE_DEBUG_JSONL_FLAG = "write-debug-jsonl";
+
+export interface DebugJsonlPolicyOptions {
+  enabled?: boolean;
+  configDir?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function resolveDebugJsonlPath(
+  options: DebugJsonlPolicyOptions = {},
+): string | undefined {
+  if (!options.enabled) {
+    return undefined;
+  }
+
+  const env = options.env ?? process.env;
+  return (
+    env.JIN_DIAGNOSTIC_LOG ||
+    join(options.configDir ?? defaultConfigDir(), "debug.jsonl")
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { VERSION } from "./updater";
+import { WRITE_DEBUG_JSONL_FLAG } from "./diagnostics/debug-jsonl";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -52,7 +53,7 @@ function readConfigRestartFlag(): boolean {
 }
 
 function readWriteDebugJsonlFlag(): boolean {
-  return parseBooleanFlag(flags["write-debug-jsonl"]) === true;
+  return parseBooleanFlag(flags[WRITE_DEBUG_JSONL_FLAG]) === true;
 }
 
 const COMMAND_HELP: Record<string, string> = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -571,7 +571,9 @@ async function main(): Promise<void> {
             console.error("Usage: jin sink repush <sink-id>");
             process.exit(1);
           }
-          await sinkRepushCommand(sinkId);
+          await sinkRepushCommand(sinkId, {
+            writeDebugJsonl: readWriteDebugJsonlFlag(),
+          });
           break;
         default:
           console.error(`Unknown sink action: ${action || "(missing)"}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,10 @@ function readConfigRestartFlag(): boolean {
   return !!flags.restart;
 }
 
+function readWriteDebugJsonlFlag(): boolean {
+  return parseBooleanFlag(flags["write-debug-jsonl"]) === true;
+}
+
 const COMMAND_HELP: Record<string, string> = {
   search: `
   Search local conversation content
@@ -385,10 +389,16 @@ async function main(): Promise<void> {
       }
       if (flags.foreground) {
         const { watchCommand } = await import("./commands/watch");
-        await watchCommand({ daemon: false });
+        await watchCommand({
+          daemon: false,
+          writeDebugJsonl: readWriteDebugJsonlFlag(),
+        });
       } else {
         const { startCommand } = await import("./commands/start");
-        await startCommand({ service: !!flags.service });
+        await startCommand({
+          service: !!flags.service,
+          writeDebugJsonl: readWriteDebugJsonlFlag(),
+        });
       }
       break;
     }
@@ -412,7 +422,10 @@ async function main(): Promise<void> {
         ]);
       }
       const { restartCommand } = await import("./commands/start");
-      await restartCommand({ service: !!flags.service });
+      await restartCommand({
+        service: !!flags.service,
+        writeDebugJsonl: readWriteDebugJsonlFlag(),
+      });
       break;
     }
     case "ingest": {
@@ -744,7 +757,9 @@ async function main(): Promise<void> {
     case "service": {
       const { serviceCommand } = await import("./commands/service");
       const action = args[1];
-      await serviceCommand(action);
+      await serviceCommand(action, {
+        writeDebugJsonl: readWriteDebugJsonlFlag(),
+      });
       break;
     }
     case "desktop": {

--- a/src/updater.ts
+++ b/src/updater.ts
@@ -12,7 +12,7 @@ const PID_FILE = join(configDir(), "jin.pid");
 const BACKUP_PATH_FILE = join(configDir(), "jin.bak.path");
 
 // Embedded at build time — bump in package.json
-export const VERSION = "0.10.2";
+export const VERSION = "0.10.3";
 
 interface GithubRelease {
   tag_name: string;

--- a/test/acceptance/verify.ts
+++ b/test/acceptance/verify.ts
@@ -246,6 +246,7 @@ console.log(`  version: ${versionResult.stdout.trim()}`);
 const helpResult = await run(["--help"], jinEnv);
 assert("jin --help exits cleanly", helpResult.exitCode === 0);
 assert("jin --help mentions start", helpResult.stdout.includes("start"));
+assert("jin --help hides debug JSONL flag", !helpResult.stdout.includes("write-debug-jsonl"));
 
 // ─── Phase 1: Seed fixture data ──────────────────────────────────────────
 
@@ -311,7 +312,7 @@ console.log("");
 console.log("PHASE 2: JIN START --FOREGROUND (BOOTSTRAP + DAEMON)");
 
 // Start jin in foreground mode, let it do initial ingest, then kill it
-const daemonProc = Bun.spawn([JIN_BIN, "start", "--foreground"], {
+const daemonProc = Bun.spawn([JIN_BIN, "start", "--foreground", "--write-debug-jsonl"], {
   stdout: "pipe",
   stderr: "pipe",
   env: { ...process.env, ...jinEnv, JIN_DAEMON: "1" },

--- a/test/cli-surface-cleanup.test.ts
+++ b/test/cli-surface-cleanup.test.ts
@@ -24,6 +24,7 @@ test("jin help no longer advertises removed UI and v1 bridge commands", async ()
   expect(result.stdout).not.toContain(" init ");
   expect(result.stdout).not.toContain(" team-config ");
   expect(result.stdout).not.toContain(" sessions ");
+  expect(result.stdout).not.toContain("write-debug-jsonl");
 });
 
 test("jin help for connect/start/stop no longer shows removed compatibility flags", async () => {
@@ -37,6 +38,7 @@ test("jin help for connect/start/stop no longer shows removed compatibility flag
   expect(start.stdout).not.toContain("--ui");
   expect(start.stdout).not.toContain("--all");
   expect(start.stdout).not.toContain("--port");
+  expect(start.stdout).not.toContain("write-debug-jsonl");
   expect(stop.stdout).not.toContain("--ui");
 });
 

--- a/test/config-mutation-control.test.ts
+++ b/test/config-mutation-control.test.ts
@@ -679,6 +679,7 @@ describe("config mutation and control commands", () => {
     expect(console_.logs.join("\n")).toContain(
       "Repush complete. attempts 1, pushed 1, failed 0.",
     );
+    expect(existsSync(join(runtimePaths.configDir, "debug.jsonl"))).toBe(false);
   });
 
   test("connect resolves project routing to remote matches and preserves sink identity metadata", async () => {

--- a/test/debug-jsonl-policy.test.ts
+++ b/test/debug-jsonl-policy.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "path";
+import { resolveDebugJsonlPath } from "../src/diagnostics/debug-jsonl";
+
+describe("debug JSONL policy", () => {
+  test("JIN_DIAGNOSTIC_LOG is a path override, not an enable switch", () => {
+    const env = { JIN_DIAGNOSTIC_LOG: "/tmp/custom-debug.jsonl" };
+
+    expect(
+      resolveDebugJsonlPath({
+        enabled: false,
+        configDir: "/tmp/jin-config",
+        env,
+      }),
+    ).toBeUndefined();
+  });
+
+  test("explicit opt-in uses the configured override path", () => {
+    const env = { JIN_DIAGNOSTIC_LOG: "/tmp/custom-debug.jsonl" };
+
+    expect(
+      resolveDebugJsonlPath({
+        enabled: true,
+        configDir: "/tmp/jin-config",
+        env,
+      }),
+    ).toBe("/tmp/custom-debug.jsonl");
+  });
+
+  test("explicit opt-in falls back to config-dir debug.jsonl", () => {
+    expect(
+      resolveDebugJsonlPath({
+        enabled: true,
+        configDir: "/tmp/jin-config",
+        env: {},
+      }),
+    ).toBe(join("/tmp/jin-config", "debug.jsonl"));
+  });
+});

--- a/test/runtime-store-cutover.test.ts
+++ b/test/runtime-store-cutover.test.ts
@@ -7,7 +7,7 @@ import {
   mock,
   test,
 } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -138,6 +138,7 @@ afterEach(() => {
   exitMock?.restore();
   exitMock = null;
   delete process.env.JIN_CONFIG_DIR;
+  delete process.env.JIN_DIAGNOSTIC_LOG;
   delete process.env.JIN_RSS_WARNING_MB;
   delete process.env.JIN_RSS_HARD_LIMIT_MB;
   rmSync(tempDir, { recursive: true, force: true });
@@ -153,6 +154,7 @@ describe("W3-RUNTIME-01 live cutover", () => {
     exitMock = mockProcessExit();
     process.env.JIN_RSS_WARNING_MB = "123";
     process.env.JIN_RSS_HARD_LIMIT_MB = "456";
+    process.env.JIN_DIAGNOSTIC_LOG = join(tempDir, "ignored-debug.jsonl");
 
     const watchPromise = watchCommand({ daemon: false });
     await Bun.sleep(30);
@@ -175,6 +177,7 @@ describe("W3-RUNTIME-01 live cutover", () => {
       deferWatcherStart?: boolean;
       rssWarningBytes?: number;
       rssHardLimitBytes?: number;
+      diagnosticLogPath?: string;
     };
 
     expect(typeof options.store.writeBundle).toBe("function");
@@ -185,11 +188,47 @@ describe("W3-RUNTIME-01 live cutover", () => {
     expect(options.deferWatcherStart).toBe(true);
     expect(options.rssWarningBytes).toBeUndefined();
     expect(options.rssHardLimitBytes).toBeUndefined();
+    expect(options.diagnosticLogPath).toBeUndefined();
+    expect(
+      (startLocalApiServerCalls[0] as { diagnosticLogPath?: string })
+        .diagnosticLogPath,
+    ).toBeUndefined();
+    expect(existsSync(join(tempDir, "ignored-debug.jsonl"))).toBe(false);
+    expect(existsSync(join(tempDir, "debug.jsonl"))).toBe(false);
 
     const adapters = await options.adapterSource();
     expect(adapters).toHaveLength(1);
     expect(typeof adapters[0].findChanged).toBe("function");
     expect(typeof adapters[0].loadConversation).toBe("function");
+  });
+
+  test("watchCommand enables diagnostic JSONL only through the hidden flag", async () => {
+    mockAdapters = [createV2CapableAdapter("watch-debug-opt-in-conversation")];
+    exitMock = mockProcessExit();
+    const diagnosticPath = join(tempDir, "custom-debug.jsonl");
+    process.env.JIN_DIAGNOSTIC_LOG = diagnosticPath;
+
+    const watchPromise = watchCommand({
+      daemon: false,
+      writeDebugJsonl: true,
+    });
+    await Bun.sleep(30);
+    process.emit("SIGTERM");
+
+    await expect(watchPromise).rejects.toBeInstanceOf(ExitError);
+    expect(runPipelineCalls).toHaveLength(1);
+    expect(startLocalApiServerCalls).toHaveLength(1);
+
+    const options = runPipelineCalls[0] as {
+      diagnosticLogPath?: string;
+    };
+
+    expect(options.diagnosticLogPath).toBe(diagnosticPath);
+    expect(
+      (startLocalApiServerCalls[0] as { diagnosticLogPath?: string })
+        .diagnosticLogPath,
+    ).toBe(diagnosticPath);
+    expect(existsSync(diagnosticPath)).toBe(true);
   });
 
   test("watchCommand disables a corrupt discovery cache instead of crashing startup", async () => {


### PR DESCRIPTION
## Summary
- make daemon diagnostic debug.jsonl writes explicitly opt-in via hidden --write-debug-jsonl
- keep default daemon/service runs on bounded logs/status instead of debug JSONL
- bump release version to 0.10.3

## Validation
- bun run typecheck
- bun test test/runtime-store-cutover.test.ts test/cli-surface-cleanup.test.ts