### PR TITLE
Fix daemon owner metadata drift

### DIFF
--- a/docs/solutions/2026-05-28-daemon-owner-metadata-must-self-heal.md
+++ b/docs/solutions/2026-05-28-daemon-owner-metadata-must-self-heal.md
@@ -1,0 +1,64 @@
+---
+title: Daemon Owner Metadata Must Self-Heal Before Lifecycle Actions
+date: 2026-05-28
+tags: [daemon, lifecycle, desktop]
+related: [BP-11, W3-RUNTIME-01]
+---
+
+# Daemon Owner Metadata Must Self-Heal Before Lifecycle Actions
+
+## Problem
+
+A live Jin runtime can keep serving the local API socket after `jin.pid` and
+`jin.runtime.json` disappear or drift. In that state, file-based status reports
+`stopped` while the socket still belongs to a running process. A subsequent
+`jin start` can then try to create a second runtime owner against the same
+store/socket surface.
+
+## Solution
+
+Keep daemon ownership policy centralized in `runtime-state.ts` and make cleanup
+compare the expected owner before deleting metadata. A running local control
+boundary now reports status from the current process, and control actions repair
+that owner metadata before delegating to CLI lifecycle commands. CLI start paths
+also probe the local control socket when file metadata says stopped, and refuse
+to spawn a second owner if the socket is already responding.
+
+## Key Insight
+
+PID files are only hints unless every writer treats them as conditional owner
+records. Lifecycle actions need a second source of truth: either the supervisor
+or the daemon's own control socket. For Jin, the socket is the local arbiter
+that can self-identify the active process and restore missing metadata.
+
+## Prevention
+
+- Clear `jin.pid` and `jin.runtime.json` only when the current file still
+  belongs to the expected owner.
+- Treat persisted runtime state from a drifted owner as stale before applying
+  states such as `stopping` or `degraded`.
+- Compare PID, mode, paths, and process start time when detecting owner drift.
+- Before spawning a detached daemon or enabling service mode from a stopped
+  file state, probe `/api/control/status` on the local socket.
+- Repair current-process owner metadata before a live control API delegates
+  `start`, `stop`, or `restart` to the CLI.
+- Cover lifecycle edge cases with contained temp-config tests instead of using
+  the developer's real daemon state.
+
+## Related
+
+- `docs/blueprint/BP-11-desktop-daemon-boundary.md`
+- `test/runtime-state-local-owner.test.ts`
+- `test/lifecycle-boundary.test.ts`
+
+## Files Changed
+
+- `src/daemon/runtime-state.ts`
+- `src/daemon/process-state.ts`
+- `src/commands/start.ts`
+- `src/commands/watch.ts`
+- `src/api/control.ts`
+- `src/api/client.ts`
+- `test/runtime-state-local-owner.test.ts`
+- `test/lifecycle-boundary.test.ts`
+- `test/local-control-boundary.test.ts`

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,6 @@
 import { getRuntimePaths } from "../daemon/runtime-state";
 import { DESKTOP_AUTH_HEADER, getDesktopApiToken } from "./auth";
+import type { DesktopControlStatus } from "../contracts/desktop";
 
 export type ConfigReloadNotificationResult =
   | {
@@ -23,6 +24,17 @@ export interface RequestConfigReloadOptions {
   token?: string;
   timeoutMs?: number;
 }
+
+export type LocalControlStatusProbeResult =
+  | {
+      status: "available";
+      statusCode: number;
+      control: DesktopControlStatus;
+    }
+  | {
+      status: "failed";
+      message: string;
+    };
 
 interface BunUnixRequestInit extends RequestInit {
   unix?: string;
@@ -74,13 +86,53 @@ export async function requestDaemonConfigReload(
   }
 }
 
+export async function requestDaemonControlStatus(
+  options: RequestConfigReloadOptions = {},
+): Promise<LocalControlStatusProbeResult> {
+  const endpoint = options.endpoint ?? getRuntimePaths().localEndpoint;
+  const token = options.token ?? getDesktopApiToken();
+  const fetchImpl = options.fetch ?? fetch;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort(new Error("local daemon API request timed out"));
+  }, options.timeoutMs ?? DEFAULT_RELOAD_REQUEST_TIMEOUT_MS);
+
+  try {
+    const response = await fetchImpl(
+      buildLocalApiUrl(endpoint, "/api/control/status"),
+      buildRequestInit(endpoint, token, controller.signal, "GET"),
+    );
+    const payload = await readJsonObject(response);
+    if (!response.ok || !isControlStatus(payload)) {
+      return {
+        status: "failed",
+        message: `Control status request failed with HTTP ${response.status}.`,
+      };
+    }
+
+    return {
+      status: "available",
+      statusCode: response.status,
+      control: payload,
+    };
+  } catch (error) {
+    return {
+      status: "failed",
+      message: formatError(error),
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 function buildRequestInit(
   endpoint: string,
   token: string,
   signal: AbortSignal,
+  method: "GET" | "POST" = "POST",
 ): BunUnixRequestInit {
   const init: BunUnixRequestInit = {
-    method: "POST",
+    method,
     signal,
     headers: {
       [DESKTOP_AUTH_HEADER]: token,
@@ -124,6 +176,13 @@ function readPayloadMessage(payload: Record<string, any> | null): string | null 
 
 function isRecord(value: unknown): value is Record<string, any> {
   return typeof value === "object" && value !== null;
+}
+
+function isControlStatus(value: unknown): value is DesktopControlStatus {
+  if (!isRecord(value) || !isRecord(value.runtime)) {
+    return false;
+  }
+  return typeof value.runtime.state === "string";
 }
 
 function formatError(error: unknown): string {

--- a/src/api/control.ts
+++ b/src/api/control.ts
@@ -6,6 +6,7 @@ import { posix, win32 } from "path";
 import {
   getRuntimePaths,
   getRuntimeStatus,
+  getRuntimeStatusForCurrentProcess,
 } from "../daemon/runtime-state";
 import type {
   DesktopControlAction,
@@ -17,6 +18,8 @@ import type {
 } from "../contracts/desktop";
 import type {
   RuntimeIssue,
+  RuntimeMode,
+  RuntimeStatus,
   RuntimeState,
 } from "../contracts/lifecycle";
 
@@ -45,6 +48,7 @@ export interface LocalControlBoundary {
 }
 
 export interface LocalControlBoundaryOptions {
+  currentRuntimeMode?: RuntimeMode;
   executeAction?: (
     action: LocalControlAction,
   ) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
@@ -67,12 +71,23 @@ export function createLocalControlBoundary(
   options: LocalControlBoundaryOptions = {},
 ): LocalControlBoundary {
   const executeAction = options.executeAction ?? executeLifecycleAction;
-  const getStatus = options.getStatus ?? getLocalControlStatus;
+  const getCurrentRuntimeStatus = options.currentRuntimeMode
+    ? () => getRuntimeStatusForCurrentProcess(options.currentRuntimeMode!)
+    : null;
+  const getStatus =
+    options.getStatus ??
+    (() =>
+      getLocalControlStatus(
+        getCurrentRuntimeStatus
+          ? { runtime: getCurrentRuntimeStatus() }
+          : undefined,
+      ));
   const requestConfigReload = options.requestConfigReload;
 
   return {
     getStatus,
     async runAction(action) {
+      getCurrentRuntimeStatus?.();
       const result = await executeAction(action);
       return {
         action,
@@ -118,10 +133,14 @@ export function createLocalControlBoundary(
   };
 }
 
-export function getLocalControlStatus(): LocalControlStatusDto {
-  const runtime = getRuntimeStatus();
+export function getLocalControlStatus(options: {
+  runtime?: RuntimeStatus;
+} = {}): LocalControlStatusDto {
+  const runtime = options.runtime ?? getRuntimeStatus();
   const issues = runtime.issues ?? [];
-  const components = getAllState().map((component) => ({ ...component }));
+  const components = options.runtime
+    ? componentsForRuntime(runtime)
+    : getAllState().map((component) => ({ ...component }));
   const paths = getRuntimePaths();
 
   return {
@@ -154,6 +173,23 @@ export function getLocalControlStatus(): LocalControlStatusDto {
       socket: paths.socketPath,
     },
   };
+}
+
+function componentsForRuntime(runtime: RuntimeStatus): LocalControlComponentDto[] {
+  if (runtime.state === "stopped" || !runtime.owner) {
+    return [{ name: "watcher", status: "stopped", lifecycleState: "stopped" }];
+  }
+
+  return [
+    {
+      name: "watcher",
+      status: "running",
+      pid: runtime.owner.pid,
+      mode: runtime.owner.mode,
+      lifecycleState: runtime.state,
+      ...(runtime.issues.length > 0 ? { issues: runtime.issues } : {}),
+    },
+  ];
 }
 
 async function executeLifecycleAction(

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,4 +1,5 @@
 import { SHUTDOWN_DRAIN_TIMEOUT_MS } from "../contracts/lifecycle";
+import { requestDaemonControlStatus } from "../api/client";
 import {
   getWatcherState,
   stopWatcher,
@@ -24,6 +25,11 @@ export async function startCommand(opts: {
 
   // --service: install as OS service
   if (opts.service) {
+    if (watcherState.status !== "running" && await localSocketResponds()) {
+      printRespondingSocketRefusal("enable service mode");
+      return;
+    }
+
     if (watcherState.status === "running" && watcherState.mode === "service") {
       console.log("  jin is already running under the OS service manager.");
       console.log("  Use service control or `jin service status` for details.");
@@ -65,6 +71,11 @@ export async function startCommand(opts: {
       console.log("  Use `jin status` or `jin stop` instead of starting a second owner.");
     }
   } else {
+    if (await localSocketResponds()) {
+      printRespondingSocketRefusal("start a detached daemon");
+      return;
+    }
+
     if (isServiceInstalled()) {
       console.log("  Note: OS service is installed but not active.");
       console.log("  The service may start on reboot. Consider `jin start --service` instead.\n");
@@ -88,6 +99,17 @@ export async function startCommand(opts: {
     }
   }
 
+}
+
+async function localSocketResponds(): Promise<boolean> {
+  const probe = await requestDaemonControlStatus({ timeoutMs: 500 });
+  return probe.status === "available";
+}
+
+function printRespondingSocketRefusal(action: string): void {
+  console.log("  A Jin daemon socket is already responding, but local owner metadata is missing.");
+  console.log(`  Refusing to ${action} because that could create a second runtime owner.`);
+  console.log("  Run `jin stop` or remove the stale runtime process before retrying.");
 }
 
 export async function restartCommand(opts: {

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -26,13 +26,14 @@ import {
   appendFileSync,
   existsSync,
   readFileSync,
-  unlinkSync,
   watch,
   writeFileSync,
   type FSWatcher,
 } from "fs";
 import { basename, join } from "path";
 import { resolveSelfCommand } from "../runtime/self-command";
+import { clearRuntimePidFile } from "../daemon/runtime-state";
+import type { RuntimeMode } from "../contracts/lifecycle";
 
 type RuntimeLog = (message: string) => void;
 const CONFIG_RELOAD_WATCH_DEBOUNCE_MS = 150;
@@ -149,6 +150,7 @@ export async function watchCommand(opts: {
     apiServer = startLocalApiServer({
       queryStore: store,
       controlBoundary: createLocalControlBoundary({
+        currentRuntimeMode: currentRuntimeMode(),
         requestConfigReload: () => pipelineHandle.reloadConfig("command"),
       }),
       diagnosticLogPath: diagnosticPath,
@@ -642,9 +644,17 @@ function isRunning(): boolean {
 }
 
 function cleanup(): void {
-  try {
-    unlinkSync(pidFilePath());
-  } catch {}
+  clearRuntimePidFile(process.pid);
+}
+
+function currentRuntimeMode(): RuntimeMode {
+  if (process.env.JIN_LAUNCHED_BY_SERVICE) {
+    return "service";
+  }
+  if (process.env.JIN_DAEMON) {
+    return "daemon";
+  }
+  return "foreground";
 }
 
 function formatError(error: unknown): string {

--- a/src/daemon/process-state.ts
+++ b/src/daemon/process-state.ts
@@ -1,7 +1,6 @@
-import { readFileSync, unlinkSync } from "fs";
+import { readFileSync } from "fs";
 import { spawnSync } from "node:child_process";
 import { join } from "path";
-import { configDir } from "../config";
 import {
   SHUTDOWN_DRAIN_TIMEOUT_MS,
   type RuntimeIssue,
@@ -10,13 +9,13 @@ import {
   type RuntimeState,
 } from "../contracts/lifecycle";
 import {
+  clearRuntimePidFile,
   clearRuntimeState,
   getRuntimeStatus,
   markRuntimeStopping,
 } from "./runtime-state";
 import { windowsTaskIdentityPowerShellLines } from "../windows-task";
 
-const PID_FILE = join(configDir(), "jin.pid");
 const DEFAULT_STOP_WAIT_MS = 2_000;
 
 export interface ComponentState {
@@ -74,7 +73,6 @@ export async function stopWatcher(
 ): Promise<StopWatcherResult> {
   const runtime = getRuntimeStatus();
   if (runtime.state === "stopped" || !runtime.owner) {
-    cleanupPidFile(PID_FILE);
     clearRuntimeState();
     return {
       requested: false,
@@ -92,8 +90,8 @@ export async function stopWatcher(
     await requestServiceStop();
     const completed = await waitForServiceStop(waitForExitMs);
     if (completed) {
-      cleanupPidFile(PID_FILE);
-      clearRuntimeState();
+      clearRuntimePidFile(runtime.owner);
+      clearRuntimeState(runtime.owner);
     }
     return {
       requested: true,
@@ -107,8 +105,8 @@ export async function stopWatcher(
   try {
     process.kill(runtime.owner.pid, "SIGTERM");
   } catch {
-    cleanupPidFile(PID_FILE);
-    clearRuntimeState();
+    clearRuntimePidFile(runtime.owner);
+    clearRuntimeState(runtime.owner);
     return {
       requested: true,
       completed: true,
@@ -120,8 +118,8 @@ export async function stopWatcher(
 
   const completed = await waitForPidExit(runtime.owner.pid, waitForExitMs);
   if (completed) {
-    cleanupPidFile(PID_FILE);
-    clearRuntimeState();
+    clearRuntimePidFile(runtime.owner);
+    clearRuntimeState(runtime.owner);
     return {
       requested: true,
       completed: true,
@@ -147,8 +145,8 @@ export async function stopWatcher(
 
   const forced = await waitForPidExit(runtime.owner.pid, 1_000);
   if (forced) {
-    cleanupPidFile(PID_FILE);
-    clearRuntimeState();
+    clearRuntimePidFile(runtime.owner);
+    clearRuntimeState(runtime.owner);
   }
 
   return {
@@ -279,12 +277,6 @@ async function waitForServiceStop(timeoutMs: number): Promise<boolean> {
   }
 
   return false;
-}
-
-function cleanupPidFile(path: string): void {
-  try {
-    unlinkSync(path);
-  } catch {}
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/daemon/runtime-state.ts
+++ b/src/daemon/runtime-state.ts
@@ -211,15 +211,17 @@ export function getRuntimeStatus(): RuntimeStatus {
 
   if (!owner) {
     if (persisted) {
-      clearRuntimeState();
+      clearRuntimeState(persisted.owner ?? null);
     }
     return { state: "stopped", issues: [] };
   }
 
-  const issues = persisted?.issues ?? [];
-  const state = resolveRuntimeState(owner, persisted, issues);
+  const ownerDrifted = !persisted || hasOwnerDrifted(owner, persisted.owner);
+  const activePersisted = ownerDrifted ? null : persisted;
+  const issues = activePersisted?.issues ?? [];
+  const state = resolveRuntimeState(owner, activePersisted, issues);
 
-  if (!persisted || hasOwnerDrifted(owner, persisted.owner)) {
+  if (ownerDrifted) {
     writePersistedRuntimeState(state, owner, issues);
   }
 
@@ -228,6 +230,41 @@ export function getRuntimeStatus(): RuntimeStatus {
     owner,
     issues,
   };
+}
+
+export function getRuntimeStatusForCurrentProcess(
+  mode: RuntimeMode,
+  issues: RuntimeIssue[] = [],
+): RuntimeStatus {
+  const owner = createCurrentProcessRuntimeOwner(mode);
+  const persisted = readPersistedRuntimeState();
+  const ownerDrifted = !persisted || hasOwnerDrifted(owner, persisted.owner);
+  const activePersisted = ownerDrifted ? null : persisted;
+  const activeIssues = activePersisted?.issues ?? issues;
+  const state = resolveRuntimeState(owner, activePersisted, activeIssues);
+
+  writePidFileForOwner(owner);
+  if (ownerDrifted) {
+    writePersistedRuntimeState(state, owner, activeIssues);
+  }
+
+  return {
+    state,
+    owner,
+    issues: activeIssues,
+  };
+}
+
+export function createCurrentProcessRuntimeOwner(
+  mode: RuntimeMode,
+): RuntimeOwnershipRecord {
+  const persisted = readPersistedRuntimeState();
+  return buildOwnershipRecord(
+    process.pid,
+    mode,
+    getRuntimePaths(),
+    persisted?.owner,
+  );
 }
 
 export function markRuntimeStarting(modeHint?: RuntimeMode): RuntimeStatus {
@@ -252,10 +289,22 @@ export function markRuntimeStopping(owner?: RuntimeOwnershipRecord): RuntimeStat
   return getRuntimeStatus();
 }
 
-export function clearRuntimeState(): void {
+export function clearRuntimeState(owner?: RuntimeOwnershipRecord | null): void {
+  if (owner && !runtimeStateMatchesOwner(owner)) {
+    return;
+  }
+
   try {
     unlinkSync(RUNTIME_STATE_FILE);
   } catch {}
+}
+
+export function clearRuntimePidFile(
+  ownerOrPid?: RuntimeOwnershipRecord | number | null,
+): void {
+  const expectedPid =
+    typeof ownerOrPid === "number" ? ownerOrPid : ownerOrPid?.pid;
+  cleanupPidFile(expectedPid);
 }
 
 /** Get the current run mode. */
@@ -382,10 +431,16 @@ function buildOwnershipRecord(
   paths: RuntimePaths,
   prior?: RuntimeOwnershipRecord,
 ): RuntimeOwnershipRecord {
+  const currentStartedAt = getProcessStartedAt(pid);
+  const priorMatchesLiveProcess =
+    prior &&
+    prior.pid === pid &&
+    prior.mode === mode &&
+    (!currentStartedAt || prior.startedAt === currentStartedAt);
   const startedAt =
-    prior && prior.pid === pid && prior.mode === mode
+    priorMatchesLiveProcess
       ? prior.startedAt
-      : getProcessStartedAt(pid) ?? new Date().toISOString();
+      : currentStartedAt ?? new Date().toISOString();
 
   return {
     pid,
@@ -404,14 +459,15 @@ function readLivePid(): number | null {
   }
 
   try {
-    const pid = parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
+    const pidText = readFileSync(PID_FILE, "utf-8").trim();
+    const pid = parseInt(pidText, 10);
     if (!Number.isFinite(pid) || pid <= 0) {
       cleanupPidFile();
       return null;
     }
 
     if (!isPidAlive(pid)) {
-      cleanupPidFile();
+      cleanupPidFile(pid);
       return null;
     }
 
@@ -530,6 +586,22 @@ function writePersistedRuntimeState(
   } catch {}
 }
 
+function writePidFileForOwner(owner: RuntimeOwnershipRecord): void {
+  try {
+    mkdirSync(configDir(), { recursive: true });
+    if (existsSync(PID_FILE)) {
+      const existing = parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
+      if (existing === owner.pid) {
+        return;
+      }
+      if (Number.isFinite(existing) && existing > 0 && isPidAlive(existing)) {
+        return;
+      }
+    }
+    writeFileSync(PID_FILE, `${owner.pid}\n`);
+  } catch {}
+}
+
 function hasOwnerDrifted(
   owner: RuntimeOwnershipRecord,
   previous?: RuntimeOwnershipRecord,
@@ -541,6 +613,7 @@ function hasOwnerDrifted(
   return (
     previous.pid !== owner.pid ||
     previous.mode !== owner.mode ||
+    previous.startedAt !== owner.startedAt ||
     previous.configDir !== owner.configDir ||
     previous.storePath !== owner.storePath ||
     previous.logPath !== owner.logPath ||
@@ -558,6 +631,14 @@ function ownershipMatchesRuntime(
     (owner.logPath ?? paths.logPath) === paths.logPath &&
     (owner.localEndpoint ?? paths.localEndpoint) === paths.localEndpoint
   );
+}
+
+function runtimeStateMatchesOwner(owner: RuntimeOwnershipRecord): boolean {
+  const persisted = readPersistedRuntimeState();
+  if (!persisted?.owner) {
+    return false;
+  }
+  return !hasOwnerDrifted(owner, persisted.owner);
 }
 
 function parseOwnershipRecord(raw: unknown): RuntimeOwnershipRecord | null {
@@ -625,7 +706,18 @@ function readRawConfig(): Record<string, any> | null {
   }
 }
 
-function cleanupPidFile(): void {
+function cleanupPidFile(expectedPid?: number): void {
+  if (typeof expectedPid === "number") {
+    try {
+      const current = parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
+      if (current !== expectedPid) {
+        return;
+      }
+    } catch {
+      return;
+    }
+  }
+
   try {
     unlinkSync(PID_FILE);
   } catch {}

--- a/test/config-mutation-control.test.ts
+++ b/test/config-mutation-control.test.ts
@@ -61,6 +61,7 @@ mock.module("../src/daemon/process-state", () => ({
 
 mock.module("../src/daemon/runtime-state", () => ({
   getRuntimeStatus: () => runtimeStatus,
+  getRuntimeStatusForCurrentProcess: () => runtimeStatus,
   getRuntimePaths: () => runtimePaths,
   isServiceActive: () => false,
   isServiceInstalled: () => false,
@@ -84,6 +85,7 @@ mock.module("../src/daemon/runtime-state", () => ({
     return runtimeStatus;
   },
   clearRuntimeState: () => {},
+  clearRuntimePidFile: () => {},
   runModeLabel: (mode: string) => mode,
 }));
 

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -34,10 +34,12 @@ mock.module("../src/sinks/registry", () => ({
 mock.module("../src/daemon/runtime-state", () => ({
   getRuntimePaths: () => runtimePaths,
   getRuntimeStatus: () => ({ state: "stopped", issues: [] }),
+  getRuntimeStatusForCurrentProcess: () => ({ state: "stopped", issues: [] }),
   isServiceInstalled: () => false,
   markRuntimeStarting: () => ({ state: "starting", issues: [] }),
   markRuntimeRunning: () => ({ state: "running", issues: [] }),
   clearRuntimeState: () => {},
+  clearRuntimePidFile: () => {},
   runModeLabel: (mode: string) => mode,
 }));
 

--- a/test/lifecycle-boundary.test.ts
+++ b/test/lifecycle-boundary.test.ts
@@ -18,6 +18,7 @@ let stopWatcherResult: any;
 let stopWatcherCalls: any[] = [];
 let watchCalls: any[] = [];
 let serviceCalls: any[] = [];
+let controlStatusProbe: any;
 let serviceInstalled = false;
 let configValue: any;
 let runtimePaths = {
@@ -42,6 +43,7 @@ mock.module("../src/daemon/runtime-state", () => ({
   clearRuntimeState: () => {},
   getRuntimePaths: () => runtimePaths,
   getRuntimeStatus: () => runtimeStatus,
+  getRuntimeStatusForCurrentProcess: () => runtimeStatus,
   isServiceInstalled: () => serviceInstalled,
   markRuntimeRunning: () => runtimeStatus,
   markRuntimeStarting: () => runtimeStatus,
@@ -57,6 +59,7 @@ mock.module("../src/daemon/runtime-state", () => ({
         return "not running";
     }
   },
+  clearRuntimePidFile: () => {},
 }));
 
 mock.module("../src/commands/watch", () => ({
@@ -69,6 +72,10 @@ mock.module("../src/commands/service", () => ({
   serviceCommand: async (action: unknown) => {
     serviceCalls.push(action);
   },
+}));
+
+mock.module("../src/api/client", () => ({
+  requestDaemonControlStatus: async () => controlStatusProbe,
 }));
 
 mock.module("../src/config", () => ({
@@ -119,6 +126,7 @@ beforeEach(() => {
   stopWatcherCalls = [];
   watchCalls = [];
   serviceCalls = [];
+  controlStatusProbe = { status: "failed", message: "socket missing" };
   serviceInstalled = false;
   configValue = { sinks: [], routes: [] };
   console_ = captureConsole();
@@ -207,6 +215,43 @@ describe("lifecycle runtime boundary", () => {
       forceAfterTimeout: true,
     });
     expect(serviceCalls).toEqual(["install"]);
+  });
+
+  test("start refuses a second owner when the local socket is already responding", async () => {
+    runtimeStatus = { state: "stopped", issues: [] };
+    watcherState = { name: "watcher", status: "stopped", lifecycleState: "stopped" };
+    controlStatusProbe = {
+      status: "available",
+      statusCode: 200,
+      control: {
+        runtime: { state: "stopped", owner: null, issues: [] },
+        health: {
+          status: "stopped",
+          issueCount: 0,
+          issueSubsystems: [],
+          paused: false,
+          ingest: "inactive",
+          push: "inactive",
+          components: { running: 0, stopped: 1 },
+        },
+        components: [{ name: "watcher", status: "stopped", lifecycleState: "stopped" }],
+        paths: {
+          configDir: runtimePaths.configDir,
+          config: runtimePaths.configPath,
+          store: runtimePaths.storePath,
+          log: runtimePaths.logPath,
+          localEndpoint: runtimePaths.localEndpoint,
+          socket: runtimePaths.socketPath,
+        },
+      },
+    };
+
+    await startCommand({});
+
+    expect(watchCalls).toHaveLength(0);
+    const output = console_.logs.join("\n");
+    expect(output).toContain("daemon socket is already responding");
+    expect(output).toContain("second runtime owner");
   });
 
   test("stop behaves like a bounded control-plane action", async () => {

--- a/test/local-control-boundary.test.ts
+++ b/test/local-control-boundary.test.ts
@@ -18,6 +18,7 @@ mock.module("../src/daemon/process-state", () => ({
 mock.module("../src/daemon/runtime-state", () => ({
   getRuntimePaths: () => runtimePaths,
   getRuntimeStatus: () => runtimeStatus,
+  getRuntimeStatusForCurrentProcess: () => runtimeStatus,
   isServiceInstalled: () => false,
   markRuntimeStarting: () => runtimeStatus,
   markRuntimeRunning: () => runtimeStatus,

--- a/test/poisoned-local-store-recovery.test.ts
+++ b/test/poisoned-local-store-recovery.test.ts
@@ -39,7 +39,9 @@ mock.module("../src/daemon/runtime-state", () => ({
   },
   getRuntimePaths: () => runtimePaths,
   getRuntimeStatus: () => runtimeStatus,
+  getRuntimeStatusForCurrentProcess: () => runtimeStatus,
   isServiceInstalled: () => false,
+  clearRuntimePidFile: () => {},
   markRuntimeRunning: () => {},
   markRuntimeStarting: () => {},
   runModeLabel: (mode: string) => mode,
@@ -49,6 +51,13 @@ mock.module("../src/commands/watch", () => ({
   watchCommand: async () => {
     throw watchFailure;
   },
+}));
+
+mock.module("../src/api/client", () => ({
+  requestDaemonControlStatus: async () => ({
+    status: "failed",
+    message: "socket missing",
+  }),
 }));
 
 mock.module("../src/config", () => ({

--- a/test/runtime-state-local-owner.test.ts
+++ b/test/runtime-state-local-owner.test.ts
@@ -7,8 +7,10 @@ import {
   unlinkSync,
   writeFileSync,
 } from "fs";
-import { tmpdir } from "os";
 import { join } from "path";
+
+const DEFAULT_PROCESS_LSTART = "Wed Apr 29 12:00:00 2026";
+const DEFAULT_PROCESS_STARTED_AT = new Date(DEFAULT_PROCESS_LSTART).toISOString();
 
 const PROBE_SCRIPT = `
 import { mock } from "bun:test";
@@ -41,7 +43,7 @@ function fakeSpawnSync(command, args = []) {
       return response("?\\n");
     }
     if (binary === "ps" && argv[0] === "-o" && argv[1] === "lstart=") {
-      return response("Mon Apr 29 12:00:00 2026\\n");
+      return response((opts.processStartedAt || "Wed Apr 29 12:00:00 2026") + "\\n");
     }
   }
 
@@ -60,7 +62,7 @@ function fakeSpawnSync(command, args = []) {
       return response("??\\n");
     }
     if (binary === "ps" && argv[0] === "-o" && argv[1] === "lstart=") {
-      return response("Mon Apr 29 12:00:00 2026\\n");
+      return response((opts.processStartedAt || "Wed Apr 29 12:00:00 2026") + "\\n");
     }
   }
 
@@ -85,14 +87,98 @@ mock.module("./src/daemon/child-process.ts", () => ({
 }));
 
 process.kill = ((pid, signal = 0) => {
-  if (signal === 0 && livePids.has(Number(pid))) {
+  if (signal === 0 && (livePids.has(Number(pid)) || Number(pid) === process.pid)) {
     return true;
   }
   throw new Error("ESRCH");
 });
 
 const runtimeState = await import("./src/daemon/runtime-state.ts");
-console.log(JSON.stringify(runtimeState.getRuntimeStatus()));
+if (opts.action === "clearPidFile") {
+  runtimeState.clearRuntimePidFile(opts.ownerPid);
+  const { existsSync, readFileSync } = await import("fs");
+  const { join } = await import("path");
+  const pidPath = join(process.env.JIN_CONFIG_DIR, "jin.pid");
+  console.log(JSON.stringify({
+    exists: existsSync(pidPath),
+    contents: existsSync(pidPath) ? readFileSync(pidPath, "utf-8").trim() : null,
+  }));
+} else if (opts.action === "selfStatus") {
+  const status = runtimeState.getRuntimeStatusForCurrentProcess("daemon");
+  const { existsSync, readFileSync } = await import("fs");
+  const { join } = await import("path");
+  const pidPath = join(process.env.JIN_CONFIG_DIR, "jin.pid");
+  const runtimePath = join(process.env.JIN_CONFIG_DIR, "jin.runtime.json");
+  console.log(JSON.stringify({
+    status,
+    pidFile: existsSync(pidPath) ? readFileSync(pidPath, "utf-8").trim() : null,
+    runtimeFileExists: existsSync(runtimePath),
+  }));
+} else if (opts.action === "selfApiStatus") {
+  const { createLocalControlBoundary } = await import("./src/api/control.ts");
+  const { startLocalApiServer } = await import("./src/api/server.ts");
+  const paths = runtimeState.getRuntimePaths();
+  let fetchHandler;
+  const server = startLocalApiServer({
+    authToken: "self-api-test-token",
+    controlBoundary: createLocalControlBoundary({ currentRuntimeMode: "daemon" }),
+    queryStore: { database: {} },
+    socketPath: paths.socketPath,
+    serve: (options) => {
+      fetchHandler = options.fetch;
+      return { stop() {} };
+    },
+  });
+  const routedResponse = await fetchHandler(new Request("http://localhost/api/control/status", {
+    headers: { "x-jin-desktop-token": "self-api-test-token" },
+  }));
+  const status = await routedResponse.json();
+  server?.stop();
+  console.log(JSON.stringify({
+    statusCode: routedResponse.status,
+    runtime: status.runtime,
+    components: status.components,
+  }));
+} else if (opts.action === "selfApiStop") {
+  const { createLocalControlBoundary } = await import("./src/api/control.ts");
+  const { startLocalApiServer } = await import("./src/api/server.ts");
+  const paths = runtimeState.getRuntimePaths();
+  let fetchHandler;
+  const server = startLocalApiServer({
+    authToken: "self-api-test-token",
+    controlBoundary: createLocalControlBoundary({
+      currentRuntimeMode: "daemon",
+      executeAction: async () => {
+        const seen = runtimeState.getRuntimeStatus();
+        return {
+          exitCode: seen.state === "running" && seen.owner?.pid === process.pid ? 0 : 1,
+          stdout: JSON.stringify(seen),
+          stderr: "",
+        };
+      },
+    }),
+    queryStore: { database: {} },
+    socketPath: paths.socketPath,
+    serve: (options) => {
+      fetchHandler = options.fetch;
+      return { stop() {} };
+    },
+  });
+  const response = await fetchHandler(new Request("http://localhost/api/control/stop", {
+    method: "POST",
+    headers: { "x-jin-desktop-token": "self-api-test-token" },
+  }));
+  const payload = await response.json();
+  server?.stop();
+  console.log(JSON.stringify({
+    statusCode: response.status,
+    ok: payload.ok,
+    seen: JSON.parse(payload.stdout),
+    runtime: payload.status.runtime,
+  }));
+} else {
+  console.log(JSON.stringify(runtimeState.getRuntimeStatus()));
+}
 `;
 
 const cleanups: string[] = [];
@@ -164,11 +250,121 @@ describe("runtime-state local ownership scoping", () => {
     expect(status.owner.mode).toBe("service");
     expect(status.owner.pid).toBe(4242);
   });
+
+  test("does not let stale stopping state poison a newer daemon owner", () => {
+    const configDir = createRuntimeEnv();
+    writeFileSync(join(configDir, "jin.pid"), "5152\n");
+    writeRuntimeState(configDir, {
+      state: "stopping",
+      owner: makeOwner(configDir, "daemon", 5151),
+      issues: [],
+      updatedAt: "2026-04-29T19:00:00.000Z",
+    });
+
+    const result = runProbe(configDir, {
+      livePids: [5152],
+    });
+
+    expect(result.exitCode).toBe(0);
+    const status = JSON.parse(result.stdout);
+    expect(status.state).toBe("running");
+    expect(status.owner.mode).toBe("daemon");
+    expect(status.owner.pid).toBe(5152);
+  });
+
+  (process.platform === "linux" || process.platform === "darwin" ? test : test.skip)(
+    "does not let stale stopping state poison a reused pid owner",
+    () => {
+      const configDir = createRuntimeEnv();
+      writeFileSync(join(configDir, "jin.pid"), "5151\n");
+      writeRuntimeState(configDir, {
+        state: "stopping",
+        owner: makeOwner(configDir, "daemon", 5151),
+        issues: [],
+        updatedAt: "2026-04-29T19:00:00.000Z",
+      });
+
+      const result = runProbe(configDir, {
+        livePids: [5151],
+        processStartedAt: "Thu Apr 30 12:00:00 2026",
+      });
+
+      expect(result.exitCode).toBe(0);
+      const status = JSON.parse(result.stdout);
+      expect(status.state).toBe("running");
+      expect(status.owner.mode).toBe("daemon");
+      expect(status.owner.pid).toBe(5151);
+      expect(status.owner.startedAt).not.toBe(DEFAULT_PROCESS_STARTED_AT);
+    },
+  );
+
+  test("stale cleanup does not remove a newer daemon pid file", () => {
+    const configDir = createRuntimeEnv();
+    writeFileSync(join(configDir, "jin.pid"), "5152\n");
+
+    const result = runProbe(configDir, {
+      action: "clearPidFile",
+      ownerPid: 5151,
+    });
+
+    expect(result.exitCode).toBe(0);
+    const status = JSON.parse(result.stdout);
+    expect(status).toEqual({ exists: true, contents: "5152" });
+  });
+
+  test("current process status repairs missing owner files for a live runtime", () => {
+    const configDir = createRuntimeEnv();
+
+    const result = runProbe(configDir, {
+      action: "selfStatus",
+    });
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.status.state).toBe("running");
+    expect(payload.status.owner.mode).toBe("daemon");
+    expect(payload.pidFile).toBe(String(payload.status.owner.pid));
+    expect(payload.runtimeFileExists).toBe(true);
+  });
+
+  test("live local control API reports current process when owner files are missing", () => {
+    const configDir = createRuntimeEnv();
+
+    const result = runProbe(configDir, {
+      action: "selfApiStatus",
+    });
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.statusCode).toBe(200);
+    expect(payload.runtime.state).toBe("running");
+    expect(payload.runtime.owner.mode).toBe("daemon");
+    expect(payload.components[0].status).toBe("running");
+    expect(payload.components[0].pid).toBe(payload.runtime.owner.pid);
+  });
+
+  test("live local control API repairs owner files before delegating stop", () => {
+    const configDir = createRuntimeEnv();
+
+    const result = runProbe(configDir, {
+      action: "selfApiStop",
+    });
+
+    expect(result.exitCode).toBe(0);
+    const payload = JSON.parse(result.stdout);
+    expect(payload.statusCode).toBe(200);
+    expect(payload.ok).toBe(true);
+    expect(payload.seen.state).toBe("running");
+    expect(payload.seen.owner.mode).toBe("daemon");
+    expect(payload.runtime.state).toBe("running");
+    expect(payload.runtime.owner.pid).toBe(payload.seen.owner.pid);
+  });
 });
 
 function createRuntimeEnv(): string {
-  const dir = mkdtempSync(join(tmpdir(), "jin-runtime-state-"));
-  mkdirSync(dir, { recursive: true });
+  const root = join(process.cwd(), ".tmp");
+  mkdirSync(root, { recursive: true });
+  const dir = mkdtempSync(join(root, "jin-runtime-state-"));
   cleanups.push(dir);
   return dir;
 }
@@ -184,7 +380,7 @@ function makeOwner(configDir: string, mode: "daemon" | "service", pid: number) {
   return {
     pid,
     mode,
-    startedAt: "2026-04-29T19:00:00.000Z",
+    startedAt: DEFAULT_PROCESS_STARTED_AT,
     configDir,
     storePath: join(configDir, "store.db"),
     logPath: join(configDir, "jin.log"),

--- a/test/runtime-store-cutover.test.ts
+++ b/test/runtime-store-cutover.test.ts
@@ -36,11 +36,13 @@ let localApiServerStopCalls = 0;
 
 mock.module("../src/daemon/runtime-state", () => ({
   getRuntimeStatus: () => runtimeStatus,
+  getRuntimeStatusForCurrentProcess: () => runtimeStatus,
   getRuntimePaths: () => runtimePaths,
   runModeLabel: (mode: string) => mode,
   isServiceActive: () => false,
   isServiceInstalled: () => false,
   clearRuntimeState: () => {},
+  clearRuntimePidFile: () => {},
   markRuntimeStarting: () => runtimeStatus,
   markRuntimeRunning: () => runtimeStatus,
   markRuntimeStopping: () => runtimeStatus,

--- a/test/team-bootstrap.test.ts
+++ b/test/team-bootstrap.test.ts
@@ -32,11 +32,13 @@ mock.module("../src/daemon/process-state", () => ({
 mock.module("../src/daemon/runtime-state", () => ({
   getRuntimePaths: () => runtimePaths,
   getRuntimeStatus: () => runtimeStatus,
+  getRuntimeStatusForCurrentProcess: () => runtimeStatus,
   isServiceActive: () => false,
   isServiceInstalled: () => false,
   markRuntimeStarting: () => runtimeStatus,
   markRuntimeRunning: () => runtimeStatus,
   clearRuntimeState: () => {},
+  clearRuntimePidFile: () => {},
   runModeLabel: (mode: string) => mode,
 }));
 


### PR DESCRIPTION
## Summary
- make live daemon control status self-identify and repair missing owner metadata
- make lifecycle cleanup owner-conditional and detect stale owner drift, including PID reuse
- guard start paths by probing the local control socket before spawning a second owner

## Validation
- bun run typecheck
- bun test test/runtime-state-local-owner.test.ts test/local-control-boundary.test.ts test/lifecycle-boundary.test.ts
- bun run test
- git diff --check