### PR TITLE
Bound Codex compacted segment loads

### DIFF
--- a/docs/solutions/2026-05-29-codex-segment-index-memory.md
+++ b/docs/solutions/2026-05-29-codex-segment-index-memory.md
@@ -1,0 +1,47 @@
+---
+title: Codex Segment Index Keeps Large JSONL Loads Bounded
+date: 2026-05-29
+tags: [adapter, pipeline, performance, discovery-cache]
+related: []
+---
+
+# Codex Segment Index Keeps Large JSONL Loads Bounded
+
+## Problem
+
+A single Codex session JSONL can contain many compacted conversations and very large records. In the observed case, a 573 MB Codex file included a 17 MB `compacted` line whose `replacement_history` embedded base64 PNG screenshots. The old Codex adapter rebuilt the full file model for each ref, so loading one compacted conversation could parse unrelated large records and push worker RSS close to 1 GB.
+
+Discovery had a separate failure mode: building the lightweight ref list still used full JSON parsing and a line scanner that repeatedly concatenated partial buffers, so even indexing could allocate far more than the final index required.
+
+## Solution
+
+The Codex discovery cache payload now stores adapter-local segment metadata: ref ids, byte offsets, turn/model context, and file-level metadata. Worker loads receive only the discovery state for the ref source path, then `loadConversation(ref)` reads only that segment byte range when offsets are available.
+
+Discovery indexing now scans raw JSONL bytes, parses only small metadata lines, and avoids expanding large `replacement_history` payloads. The line scanner accumulates chunks and performs one concat per complete line instead of repeatedly copying long partial lines.
+
+## Key Insight
+
+For adapters where one source file can contain multiple conversations, `ConversationRef` must be treated as a precise pointer, not just a post-filter after full parsing. Adapter-owned discovery cache payloads are the right place for source-format-specific offsets because the pipeline should not need to understand Codex compaction semantics.
+
+## Prevention
+
+Tests should compare cached targeted loads against full-file parse bundles, not only check that a compacted ref loads. The regression test now asserts root-name preservation, segment timestamps, and matching bundle hashes between the full parse path and the cached targeted path.
+
+When optimizing ingestion memory, measure both phases separately:
+
+- discovery/ref indexing
+- targeted conversation loading
+
+Both can parse the same large physical file, but they have different correctness and memory risks.
+
+## Related
+
+- Real repro file: 573 MB Codex JSONL with 81 refs and a 17 MB `compacted.replacement_history` line.
+- Contained repro after fix: discovery around 342 MB RSS, targeted worker loads around 190-201 MB RSS for the two large refs measured.
+
+## Files Changed
+
+- `src/adapters/codex.ts`
+- `src/pipeline/ingest.ts`
+- `src/pipeline/ingest-worker.ts`
+- `test/codex-reference-adapter.test.ts`

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -3,7 +3,6 @@ import { createHash } from "crypto";
 import { createReadStream, existsSync, readdirSync, statSync } from "fs";
 import { homedir } from "os";
 import { basename, join } from "path";
-import { createInterface } from "readline";
 import { estimateCost } from "../pricing";
 import type { DiscoveryCacheState } from "./discovery-cache";
 import type {
@@ -22,6 +21,7 @@ import type {
 } from "./types";
 
 const DEFAULT_CODEX_HOME = join(homedir(), ".codex");
+const RAW_INDEX_PARSE_LIMIT_BYTES = 1024 * 1024;
 const EMPTY_USAGE = {
   inputTokens: 0,
   outputTokens: 0,
@@ -40,6 +40,27 @@ interface CachedFileIndex {
   snapshot: FileSnapshot;
   sessionId: string;
   refIds: string[];
+  segments: CachedFileSegment[];
+  cwd: string;
+  gitRemote: string;
+  branch: string;
+  rootName: string;
+  agentNickname: string;
+  parentThreadId: string;
+  sessionTimestamp: string;
+}
+
+interface CachedFileSegment {
+  id: string;
+  startOffset: number;
+  endOffset: number;
+  startTurn: number;
+  startModel: string;
+}
+
+interface JsonlLineMeta {
+  startOffset: number;
+  endOffset: number;
 }
 
 interface TokenUsage {
@@ -94,7 +115,7 @@ export class CodexAdapter implements Adapter, V2Adapter {
   name = "Codex";
   icon = "▶";
   discoveryCacheContractVersion = 1;
-  discoveryCachePayloadVersion = 1;
+  discoveryCachePayloadVersion = 2;
 
   private readonly codexHome: string;
   private readonly sessionsDir: string;
@@ -163,7 +184,12 @@ export class CodexAdapter implements Adapter, V2Adapter {
       return null;
     }
 
-    const loaded = await this.loadFileModel(ref.sourcePath);
+    const index = await this.getFileIndex(ref.sourcePath);
+    if (index && !index.refIds.includes(ref.id)) {
+      return null;
+    }
+
+    const loaded = await this.loadFileModel(ref.sourcePath, ref.id, index ?? undefined);
     if (!loaded) {
       return null;
     }
@@ -240,6 +266,20 @@ export class CodexAdapter implements Adapter, V2Adapter {
           payload: {
             sessionId: entry.sessionId,
             refIds: entry.refIds,
+            segments: entry.segments.map((segment) => ({
+              id: segment.id,
+              startOffset: segment.startOffset,
+              endOffset: segment.endOffset,
+              startTurn: segment.startTurn,
+              startModel: segment.startModel,
+            })),
+            cwd: entry.cwd,
+            gitRemote: entry.gitRemote,
+            branch: entry.branch,
+            rootName: entry.rootName,
+            agentNickname: entry.agentNickname,
+            parentThreadId: entry.parentThreadId,
+            sessionTimestamp: entry.sessionTimestamp,
           },
         })),
     };
@@ -257,6 +297,14 @@ export class CodexAdapter implements Adapter, V2Adapter {
       const payload = source.payload as {
         sessionId?: unknown;
         refIds?: unknown;
+        segments?: unknown;
+        cwd?: unknown;
+        gitRemote?: unknown;
+        branch?: unknown;
+        rootName?: unknown;
+        agentNickname?: unknown;
+        parentThreadId?: unknown;
+        sessionTimestamp?: unknown;
       };
       const sessionId =
         typeof payload.sessionId === "string" ? payload.sessionId : "";
@@ -266,6 +314,23 @@ export class CodexAdapter implements Adapter, V2Adapter {
               typeof value === "string" && value.length > 0,
           )
         : [];
+      const segments = Array.isArray(payload.segments)
+        ? payload.segments.flatMap((value): CachedFileSegment[] => {
+            const segment = asObject(value);
+            const id = asString(segment?.id);
+            const startOffset = asNumber(segment?.startOffset) ?? 0;
+            const endOffset = asNumber(segment?.endOffset) ?? source.sizeBytes;
+            const startTurn = asNumber(segment?.startTurn) ?? -1;
+            const startModel = asString(segment?.startModel);
+            return id ? [{ id, startOffset, endOffset, startTurn, startModel }] : [];
+          })
+        : refIds.map((id) => ({
+            id,
+            startOffset: 0,
+            endOffset: source.sizeBytes,
+            startTurn: -1,
+            startModel: "",
+          }));
       if (!sessionId || refIds.length === 0) {
         continue;
       }
@@ -279,6 +344,22 @@ export class CodexAdapter implements Adapter, V2Adapter {
         snapshot,
         sessionId,
         refIds,
+        segments: segments.length > 0
+          ? segments
+          : refIds.map((id) => ({
+              id,
+              startOffset: 0,
+              endOffset: source.sizeBytes,
+              startTurn: -1,
+              startModel: "",
+            })),
+        cwd: asString(payload.cwd),
+        gitRemote: asString(payload.gitRemote),
+        branch: asString(payload.branch),
+        rootName: asString(payload.rootName),
+        agentNickname: asString(payload.agentNickname),
+        parentThreadId: asString(payload.parentThreadId),
+        sessionTimestamp: asString(payload.sessionTimestamp),
       });
     }
   }
@@ -389,21 +470,35 @@ export class CodexAdapter implements Adapter, V2Adapter {
     );
   }
 
-  private async buildFileModel(filePath: string): Promise<LocalFileModel | null> {
+  private async buildFileModel(
+    filePath: string,
+    targetSegmentId?: string,
+    cachedIndex?: CachedFileIndex,
+  ): Promise<LocalFileModel | null> {
     const fileTimestamp = this.fileTimestamp(filePath);
-    let sessionId = this.defaultSessionId(filePath);
-    let sessionIdLocked = false;
-    let parentThreadId = "";
-    let agentNickname = "";
-    let cwd = "";
-    let gitRemote = "";
-    let branch = "";
-    let sessionTimestamp = fileTimestamp;
+    let sessionId = cachedIndex?.sessionId || this.defaultSessionId(filePath);
+    let sessionIdLocked = Boolean(cachedIndex?.sessionId);
+    let parentThreadId = cachedIndex?.parentThreadId ?? "";
+    let agentNickname = cachedIndex?.agentNickname ?? "";
+    let cwd = cachedIndex?.cwd ?? "";
+    let gitRemote = cachedIndex?.gitRemote ?? "";
+    let branch = cachedIndex?.branch ?? "";
+    let sessionTimestamp = cachedIndex?.sessionTimestamp || fileTimestamp;
+    const indexedRootName = cachedIndex?.rootName ?? "";
     let currentTurn = -1;
     let currentModel = "";
     let firstUserText = "";
     let currentSegment: LocalSegment | null = null;
-    const segments: LocalSegment[] = [];
+    const segments: LocalSegment[] =
+      targetSegmentId && cachedIndex
+        ? cachedIndex.segments.map((segment) => ({
+            id: segment.id,
+            messages: [],
+            startedAt: "",
+            endedAt: "",
+            modelCounts: new Map(),
+          }))
+        : [];
     let pendingTools: ParsedToolCall[] = [];
     const pendingToolIndex = new Map<string, number>();
     let pendingThinkingContent = "";
@@ -413,18 +508,36 @@ export class CodexAdapter implements Adapter, V2Adapter {
     let pendingAssistantModel = "";
     let sawLine = false;
 
+    const getOrCreateSegment = (id: string, timestamp: string): LocalSegment => {
+      const existing = segments.find((segment) => segment.id === id);
+      if (existing) {
+        return existing;
+      }
+
+      const created = {
+        id,
+        messages: [],
+        startedAt: timestamp,
+        endedAt: timestamp,
+        modelCounts: new Map<string, number>(),
+      };
+      segments.push(created);
+      return created;
+    };
+
     const ensureSegment = (timestamp: string): LocalSegment => {
       if (!currentSegment) {
-        currentSegment = {
-          id: sessionId,
-          messages: [],
-          startedAt: timestamp,
-          endedAt: timestamp,
-          modelCounts: new Map(),
-        };
-        segments.push(currentSegment);
+        currentSegment = getOrCreateSegment(sessionId, timestamp);
       }
       return currentSegment;
+    };
+
+    const shouldRetainSegment = (segment: LocalSegment): boolean =>
+      !targetSegmentId || segment.id === targetSegmentId;
+
+    const shouldRetainCurrentSegment = (timestamp: string): boolean => {
+      const segment = currentSegment ?? ensureSegment(timestamp);
+      return shouldRetainSegment(segment);
     };
 
     const clearPendingAssistant = (): void => {
@@ -447,6 +560,12 @@ export class CodexAdapter implements Adapter, V2Adapter {
       pendingUsage.reasoningTokens > 0;
 
     const addMessage = (segment: LocalSegment, message: Omit<ParsedMessage, "sequence">): void => {
+      if (message.role === "user" && !firstUserText && message.content.trim()) {
+        firstUserText = message.content;
+      }
+      if (!shouldRetainSegment(segment)) {
+        return;
+      }
       const parsed: ParsedMessage = {
         ...message,
         sequence: segment.messages.length,
@@ -463,9 +582,6 @@ export class CodexAdapter implements Adapter, V2Adapter {
       if (parsed.model) {
         segment.modelCounts.set(parsed.model, (segment.modelCounts.get(parsed.model) ?? 0) + 1);
       }
-      if (parsed.role === "user" && !firstUserText && parsed.content.trim()) {
-        firstUserText = parsed.content;
-      }
     };
 
     const flushPendingAssistant = (timestamp: string, recordType = "synthetic_assistant"): void => {
@@ -475,8 +591,13 @@ export class CodexAdapter implements Adapter, V2Adapter {
 
       const assistantTimestamp = pendingAssistantTimestamp || timestamp || sessionTimestamp;
       const assistantModel = pendingAssistantModel || currentModel;
-      addMessage(ensureSegment(assistantTimestamp), {
-        id: stableHash(sessionId, ensureSegment(assistantTimestamp).id, recordType, `${ensureSegment(assistantTimestamp).messages.length}`),
+      const segment = ensureSegment(assistantTimestamp);
+      if (!shouldRetainSegment(segment)) {
+        clearPendingAssistant();
+        return;
+      }
+      addMessage(segment, {
+        id: stableHash(sessionId, segment.id, recordType, `${segment.messages.length}`),
         role: "assistant",
         content: "Tool call output",
         recordType,
@@ -495,6 +616,20 @@ export class CodexAdapter implements Adapter, V2Adapter {
       });
       clearPendingAssistant();
     };
+
+    const targetSegment = targetSegmentId && cachedIndex
+      ? cachedIndex.segments.find((segment) => segment.id === targetSegmentId)
+      : undefined;
+    const scanRange = targetSegment
+      ? {
+          startOffset: targetSegment.startOffset,
+          endOffset: targetSegment.endOffset,
+        }
+      : undefined;
+    if (targetSegment && targetSegment.startOffset > 0) {
+      currentTurn = targetSegment.startTurn;
+      currentModel = targetSegment.startModel;
+    }
 
     await this.scanJsonlFile(filePath, (line, index) => {
       sawLine = true;
@@ -537,6 +672,9 @@ export class CodexAdapter implements Adapter, V2Adapter {
 
       if (envelopeType === "event_msg" && payload) {
         if (asString(payload.type) === "token_count") {
+          if (targetSegmentId && currentSegment && !shouldRetainSegment(currentSegment)) {
+            return;
+          }
           pendingUsage = this.extractTokenUsage(payload);
           pendingAssistantTimestamp = timestamp || pendingAssistantTimestamp;
           pendingAssistantModel = currentModel || pendingAssistantModel;
@@ -547,14 +685,18 @@ export class CodexAdapter implements Adapter, V2Adapter {
       if (envelopeType === "compacted" && payload) {
         flushPendingAssistant(timestamp, "synthetic_assistant");
 
-        currentSegment = {
-          id: stableHash(sessionId, `compacted:${segments.length}:${asString(payload.id) || asString(payload.turn_id) || timestamp || index}`),
-          messages: [],
-          startedAt: timestamp,
-          endedAt: timestamp,
-          modelCounts: new Map(),
-        };
-        segments.push(currentSegment);
+        const compactedSegmentId =
+          targetSegment && targetSegment.startOffset > 0
+            ? targetSegment.id
+            : stableHash(sessionId, `compacted:${segments.length}:${asString(payload.id) || asString(payload.turn_id) || timestamp || index}`);
+        currentSegment = getOrCreateSegment(
+          compactedSegmentId,
+          timestamp,
+        );
+
+        if (!shouldRetainSegment(currentSegment)) {
+          return;
+        }
 
         const replacementHistory = asArray(payload.replacement_history);
         for (let historyIndex = 0; historyIndex < replacementHistory.length; historyIndex += 1) {
@@ -685,6 +827,9 @@ export class CodexAdapter implements Adapter, V2Adapter {
       }
 
       if (itemType === "reasoning") {
+        if (targetSegmentId && !shouldRetainCurrentSegment(timestamp)) {
+          return;
+        }
         pendingThinkingContent = flattenReasoningSummary(payload.summary);
         pendingThinkingTokens = Math.max(pendingThinkingTokens, pendingUsage.reasoningTokens);
         pendingAssistantTimestamp = timestamp || pendingAssistantTimestamp;
@@ -694,6 +839,9 @@ export class CodexAdapter implements Adapter, V2Adapter {
 
       if (itemType === "function_call" || itemType === "custom_tool_call" || itemType === "web_search_call") {
         const segment = ensureSegment(timestamp);
+        if (!shouldRetainSegment(segment)) {
+          return;
+        }
         const toolIndex = pendingTools.length;
         const tool = this.parseToolCall(payload, itemType, timestamp, sessionId, segment.id, toolIndex);
         pendingTools.push(tool);
@@ -707,6 +855,9 @@ export class CodexAdapter implements Adapter, V2Adapter {
       }
 
       if (itemType === "function_call_output" || itemType === "custom_tool_call_output") {
+        if (targetSegmentId && currentSegment && !shouldRetainSegment(currentSegment)) {
+          return;
+        }
         const callKey = asString(payload.call_id) || asString(payload.id);
         if (callKey && pendingToolIndex.has(callKey)) {
           const tool = pendingTools[pendingToolIndex.get(callKey) ?? 0];
@@ -717,7 +868,7 @@ export class CodexAdapter implements Adapter, V2Adapter {
         }
         pendingAssistantTimestamp = timestamp || pendingAssistantTimestamp;
       }
-    });
+    }, scanRange);
 
     if (!sawLine) {
       return null;
@@ -741,7 +892,7 @@ export class CodexAdapter implements Adapter, V2Adapter {
       cwd,
       gitRemote,
       branch,
-      rootName: summarizeName(firstUserText) || agentNickname || sessionId.slice(0, 8),
+      rootName: indexedRootName || summarizeName(firstUserText) || agentNickname || sessionId.slice(0, 8),
       agentNickname,
       parentThreadId,
       sessionTimestamp,
@@ -953,13 +1104,18 @@ export class CodexAdapter implements Adapter, V2Adapter {
     return name.startsWith("rollout-") ? name.slice("rollout-".length) : name;
   }
 
-  private async loadFileModel(filePath: string): Promise<LoadedFileModel | null> {
+  private async loadFileModel(
+    filePath: string,
+    targetSegmentId?: string,
+    cachedIndex?: CachedFileIndex,
+  ): Promise<LoadedFileModel | null> {
     const snapshot = this.readSnapshot(filePath);
     if (!snapshot) {
       return null;
     }
 
     if (
+      !targetSegmentId &&
       this.loadedFileCache?.filePath === filePath &&
       this.loadedFileCache.entry.snapshot.size === snapshot.size &&
       this.loadedFileCache.entry.snapshot.mtimeMs === snapshot.mtimeMs
@@ -967,7 +1123,7 @@ export class CodexAdapter implements Adapter, V2Adapter {
       return this.loadedFileCache.entry;
     }
 
-    const model = await this.buildFileModel(filePath);
+    const model = await this.buildFileModel(filePath, targetSegmentId, cachedIndex);
     if (!model) {
       return null;
     }
@@ -978,10 +1134,12 @@ export class CodexAdapter implements Adapter, V2Adapter {
       base: await this.resolveBase(model),
       git: this.resolveConversationGit(model),
     };
-    this.loadedFileCache = {
-      filePath,
-      entry,
-    };
+    if (!targetSegmentId) {
+      this.loadedFileCache = {
+        filePath,
+        entry,
+      };
+    }
     return entry;
   }
 
@@ -994,66 +1152,167 @@ export class CodexAdapter implements Adapter, V2Adapter {
     let currentSegmentId = "";
     let rootSegmentCreated = false;
     const refIds: string[] = [];
+    const segments: CachedFileSegment[] = [];
+    let parentThreadId = "";
+    let agentNickname = "";
+    let cwd = "";
+    let gitRemote = "";
+    let branch = "";
+    let sessionTimestamp = new Date(snapshot.mtimeMs).toISOString();
+    let currentTurn = -1;
+    let currentModel = "";
+    let firstUserText = "";
     const fallbackTimestamp = new Date(snapshot.mtimeMs).toISOString();
+    const closePreviousSegment = (endOffset: number): void => {
+      const previous = segments[segments.length - 1];
+      if (previous && previous.endOffset === snapshot.size) {
+        previous.endOffset = endOffset;
+      }
+    };
+    const addSegment = (
+      id: string,
+      startOffset: number,
+      startTurn: number,
+      startModel: string,
+    ): void => {
+      closePreviousSegment(startOffset);
+      currentSegmentId = id;
+      refIds.push(id);
+      segments.push({
+        id,
+        startOffset,
+        endOffset: snapshot.size,
+        startTurn,
+        startModel,
+      });
+    };
+    const adoptSessionId = (recordSessionId: string): void => {
+      if (!recordSessionId || sessionIdLocked) {
+        return;
+      }
+      if (
+        currentSegmentId === sessionId &&
+        refIds.length === 1 &&
+        segments.length === 1 &&
+        !rootSegmentCreated
+      ) {
+        refIds[0] = recordSessionId;
+        const firstSegment = segments[0];
+        if (firstSegment) {
+          firstSegment.id = recordSessionId;
+        }
+        currentSegmentId = recordSessionId;
+      }
+      sessionId = recordSessionId;
+      sessionIdLocked = true;
+    };
     try {
-      await this.scanJsonlFile(filePath, (line, index) => {
-        const envelopeType = asString(line.type);
-        if (envelopeType === "session_meta") {
-          const payload = asObject(line.payload);
-          const recordSessionId = asString(payload?.id);
-          if (recordSessionId && !sessionIdLocked) {
-            if (
-              currentSegmentId === sessionId &&
-              refIds.length === 1 &&
-              !rootSegmentCreated
-            ) {
-              refIds[0] = recordSessionId;
-              currentSegmentId = recordSessionId;
-            }
-            sessionId = recordSessionId;
-            sessionIdLocked = true;
+      await this.scanJsonlRawLines(filePath, (rawLine, index, meta) => {
+        if (rawLineHasType(rawLine, "session_meta")) {
+          const parsed = parseSmallJsonlLine(rawLine);
+          const payload = asObject(parsed?.payload);
+          if (payload) {
+            adoptSessionId(asString(payload.id));
+            sessionTimestamp = asString(payload.timestamp) || sessionTimestamp;
+            cwd = asString(payload.cwd) || cwd;
+            const git = asObject(payload.git);
+            gitRemote = asString(git?.repository_url) || gitRemote;
+            branch = asString(git?.branch) || branch;
+            const source = payload.source;
+            parentThreadId = this.extractParentThreadId(source) || asString(payload.forked_from_id) || parentThreadId;
+            agentNickname = this.extractAgentNickname(source) || agentNickname;
+            return;
           }
+
+          const lineText = rawLineToString(rawLine);
+          const payloadStart = lineText.indexOf("\"payload\":");
+          adoptSessionId(extractJsonStringField(lineText, "id", payloadStart));
+          sessionTimestamp = extractJsonStringField(lineText, "timestamp", payloadStart) || sessionTimestamp;
+          cwd = extractJsonStringField(lineText, "cwd", payloadStart) || cwd;
+          gitRemote = extractJsonStringField(lineText, "repository_url", payloadStart) || gitRemote;
+          branch = extractJsonStringField(lineText, "branch", payloadStart) || branch;
+          parentThreadId = extractJsonStringField(lineText, "forked_from_id", payloadStart) || parentThreadId;
           return;
         }
 
-        if (envelopeType === "compacted") {
-          const payload = asObject(line.payload);
-          const timestamp = asString(line.timestamp) || fallbackTimestamp;
-          currentSegmentId = stableHash(
-            sessionId,
-            `compacted:${refIds.length}:${asString(payload?.id) || asString(payload?.turn_id) || timestamp || index}`,
+        if (rawLineHasType(rawLine, "turn_context")) {
+          currentTurn = currentTurn < 0 ? 1 : currentTurn + 1;
+          const lineText = rawLineToString(rawLine);
+          const payloadStart = lineText.indexOf("\"payload\":");
+          cwd = extractJsonStringField(lineText, "cwd", payloadStart) || cwd;
+          currentModel = extractJsonStringField(lineText, "model", payloadStart) || currentModel;
+          return;
+        }
+
+        if (rawLineHasType(rawLine, "compacted")) {
+          const parsed = parseSmallJsonlLine(rawLine);
+          const payload = asObject(parsed?.payload);
+          const lineText = payload ? "" : rawLineToString(rawLine);
+          const payloadStart = lineText ? lineText.indexOf("\"payload\":") : -1;
+          const replacementStart = lineText.indexOf("\"replacement_history\"", payloadStart);
+          const payloadHeader = replacementStart >= 0
+            ? lineText.slice(0, replacementStart)
+            : lineText;
+          const timestamp = asString(parsed?.timestamp) || extractJsonStringField(lineText, "timestamp") || fallbackTimestamp;
+          const payloadId =
+            asString(payload?.id) ||
+            extractJsonStringField(payloadHeader, "id", payloadStart);
+          const turnId =
+            asString(payload?.turn_id) ||
+            extractJsonStringField(payloadHeader, "turn_id", payloadStart);
+          addSegment(
+            stableHash(
+              sessionId,
+              `compacted:${refIds.length}:${payloadId || turnId || timestamp || index}`,
+            ),
+            meta.startOffset,
+            currentTurn,
+            currentModel,
           );
-          refIds.push(currentSegmentId);
           return;
         }
 
-        if (rootSegmentCreated || envelopeType !== "response_item") {
+        if (rootSegmentCreated && firstUserText) {
           return;
         }
 
-        const payload = asObject(line.payload);
-        if (!payload) {
+        if (!rawLineHasType(rawLine, "response_item")) {
           return;
         }
 
-        const itemType = asString(payload.type);
+        const lineText = rawLineToString(rawLine);
+        const payloadStart = lineText.indexOf("\"payload\":");
+        if (payloadStart < 0) {
+          return;
+        }
+
+        const itemType = extractJsonStringField(lineText, "type", payloadStart);
         if (itemType === "message") {
-          const role = normalizeRole(asString(payload.role));
-          const content = flattenMessageContent(payload.content);
+          const role = normalizeRole(extractJsonStringField(lineText, "role", payloadStart));
+          if (rootSegmentCreated && role !== "user") {
+            return;
+          }
+          const content = extractMessageContentPreview(lineText, payloadStart);
+          if (role === "user" && !firstUserText && content) {
+            firstUserText = content;
+          }
+          if (rootSegmentCreated) {
+            return;
+          }
           if (role !== "assistant" && !content) {
             return;
           }
         } else if (
-          itemType !== "reasoning" &&
-          itemType !== "function_call" &&
-          itemType !== "custom_tool_call" &&
-          itemType !== "web_search_call"
+          rootSegmentCreated ||
+          (itemType !== "reasoning" &&
+            itemType !== "function_call" &&
+            itemType !== "custom_tool_call" &&
+            itemType !== "web_search_call")
         ) {
           return;
         }
 
-        currentSegmentId = sessionId;
-        refIds.push(currentSegmentId);
+        addSegment(sessionId, 0, -1, "");
         rootSegmentCreated = true;
       });
     } catch (error) {
@@ -1062,46 +1321,156 @@ export class CodexAdapter implements Adapter, V2Adapter {
 
     if (refIds.length === 0) {
       refIds.push(sessionId);
+      segments.push({
+        id: sessionId,
+        startOffset: 0,
+        endOffset: snapshot.size,
+        startTurn: -1,
+        startModel: "",
+      });
     }
 
     return {
       snapshot,
       sessionId,
       refIds,
+      segments,
+      cwd,
+      gitRemote,
+      branch,
+      rootName: summarizeName(firstUserText) || agentNickname || sessionId.slice(0, 8),
+      agentNickname,
+      parentThreadId,
+      sessionTimestamp,
     };
   }
 
   private async scanJsonlFile(
     filePath: string,
-    visit: (line: JsonObject, index: number) => void | Promise<void>,
+    visit: (
+      line: JsonObject,
+      index: number,
+      meta: JsonlLineMeta,
+    ) => void | Promise<void>,
+    range?: { startOffset: number; endOffset: number },
   ): Promise<void> {
-    let stream;
+    await this.scanJsonlRawLines(filePath, async (rawLine, index, meta) => {
+      const line = rawLineToString(rawLine).trim();
+      if (!line) {
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(line);
+        if (isObject(parsed)) {
+          await visit(parsed, index, meta);
+        }
+      } catch (error) {
+        console.warn(
+          `[codex adapter] failed to parse JSONL line in ${filePath}:`,
+          error,
+        );
+      }
+    }, range);
+  }
+
+  private async scanJsonlRawLines(
+    filePath: string,
+    visit: (
+      rawLine: Buffer,
+      index: number,
+      meta: JsonlLineMeta,
+    ) => void | Promise<void>,
+    range?: { startOffset: number; endOffset: number },
+  ): Promise<void> {
+    const startOffset = Math.max(0, Math.floor(range?.startOffset ?? 0));
+    const endOffset = Math.max(startOffset, Math.floor(range?.endOffset ?? Number.MAX_SAFE_INTEGER));
+    if (endOffset <= startOffset) {
+      return;
+    }
+
+    let stream: ReturnType<typeof createReadStream> | undefined;
     try {
-      stream = createReadStream(filePath, { encoding: "utf8" });
-      const reader = createInterface({
-        input: stream,
-        crlfDelay: Infinity,
+      stream = createReadStream(filePath, {
+        start: startOffset,
+        ...(Number.isFinite(endOffset) && endOffset < Number.MAX_SAFE_INTEGER
+          ? { end: endOffset - 1 }
+          : {}),
       });
       let index = 0;
+      let streamOffset = startOffset;
+      let pendingChunks: Buffer[] = [];
+      let pendingLength = 0;
+      let pendingOffset = startOffset;
 
-      for await (const rawLine of reader) {
-        const line = rawLine.trim();
-        if (!line) {
-          continue;
+      const processLine = async (
+        rawLine: Buffer,
+        lineStartOffset: number,
+        lineEndOffset: number,
+      ): Promise<void> => {
+        const trimmed = rawLine.length > 0 && rawLine[rawLine.length - 1] === 13
+          ? rawLine.subarray(0, rawLine.length - 1)
+          : rawLine;
+        if (trimmed.length === 0) {
+          return;
         }
 
-        try {
-          const parsed = JSON.parse(line);
-          if (isObject(parsed)) {
-            await visit(parsed, index);
-            index += 1;
+        await visit(trimmed, index, {
+          startOffset: lineStartOffset,
+          endOffset: lineEndOffset,
+        });
+        index += 1;
+      };
+
+      for await (const chunk of stream) {
+        const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        const chunkOffset = streamOffset;
+        streamOffset += bytes.length;
+        let cursor = 0;
+
+        while (true) {
+          const newlineOffset = bytes.indexOf(10, cursor);
+          if (newlineOffset < 0) {
+            break;
           }
-        } catch (error) {
-          console.warn(
-            `[codex adapter] failed to parse JSONL line in ${filePath}:`,
-            error,
-          );
+
+          const lineEndOffset = chunkOffset + newlineOffset + 1;
+          if (pendingLength > 0) {
+            const finalChunk = bytes.subarray(cursor, newlineOffset);
+            pendingChunks.push(finalChunk);
+            const rawLine = Buffer.concat(
+              pendingChunks,
+              pendingLength + finalChunk.length,
+            );
+            await processLine(rawLine, pendingOffset, lineEndOffset);
+            pendingChunks = [];
+            pendingLength = 0;
+          } else {
+            await processLine(
+              bytes.subarray(cursor, newlineOffset),
+              chunkOffset + cursor,
+              lineEndOffset,
+            );
+          }
+          cursor = newlineOffset + 1;
         }
+
+        if (cursor < bytes.length) {
+          if (pendingLength === 0) {
+            pendingOffset = chunkOffset + cursor;
+          }
+          const tail = bytes.subarray(cursor);
+          pendingChunks.push(tail);
+          pendingLength += tail.length;
+        }
+      }
+
+      if (pendingLength > 0) {
+        await processLine(
+          Buffer.concat(pendingChunks, pendingLength),
+          pendingOffset,
+          pendingOffset + pendingLength,
+        );
       }
     } catch (error) {
       console.warn(`[codex adapter] failed to read ${filePath}:`, error);
@@ -1329,6 +1698,142 @@ function stableHash(...parts: string[]): string {
   return createHash("sha1")
     .update(parts.join("\u241f"))
     .digest("hex");
+}
+
+function rawLineHasType(rawLine: Buffer, type: string): boolean {
+  return rawLine.indexOf(`"type":"${type}"`) >= 0;
+}
+
+function rawLineToString(rawLine: Buffer): string {
+  return rawLine.toString("utf8");
+}
+
+function parseSmallJsonlLine(rawLine: Buffer): JsonObject | null {
+  if (rawLine.byteLength > RAW_INDEX_PARSE_LIMIT_BYTES) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(rawLineToString(rawLine));
+    return isObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractJsonStringField(
+  text: string,
+  field: string,
+  fromIndex = 0,
+): string {
+  const start = Math.max(0, fromIndex);
+  const keyIndex = text.indexOf(`"${field}":`, start);
+  if (keyIndex < 0) {
+    return "";
+  }
+
+  let valueIndex = keyIndex + field.length + 3;
+  while (valueIndex < text.length && /\s/.test(text[valueIndex])) {
+    valueIndex += 1;
+  }
+  if (text[valueIndex] !== "\"") {
+    return "";
+  }
+
+  return extractJsonStringPreview(text, valueIndex);
+}
+
+function extractMessageContentPreview(text: string, payloadStart: number): string {
+  const contentIndex = text.indexOf("\"content\":", payloadStart);
+  if (contentIndex < 0) {
+    return "";
+  }
+
+  let valueIndex = contentIndex + "\"content\":".length;
+  while (valueIndex < text.length && /\s/.test(text[valueIndex])) {
+    valueIndex += 1;
+  }
+
+  if (text[valueIndex] === "\"") {
+    return extractJsonStringPreview(text, valueIndex);
+  }
+
+  const textIndex = text.indexOf("\"text\":", contentIndex);
+  if (textIndex >= 0) {
+    return extractJsonStringField(text, "text", textIndex);
+  }
+
+  const nestedContentIndex = text.indexOf("\"content\":", contentIndex + 1);
+  if (nestedContentIndex >= 0) {
+    return extractJsonStringField(text, "content", nestedContentIndex);
+  }
+
+  return "";
+}
+
+function extractJsonStringPreview(
+  text: string,
+  quoteIndex: number,
+  maxChars = 240,
+): string {
+  let result = "";
+  let chunkStart = quoteIndex + 1;
+  for (let index = quoteIndex + 1; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "\\") {
+      result = appendPreviewSlice(result, text.slice(chunkStart, index), maxChars);
+      const escaped = text[index + 1] ?? "";
+      if (result.length < maxChars) {
+        result += decodeJsonEscape(escaped, text.slice(index + 2, index + 6));
+      }
+      index += escaped === "u" ? 5 : 1;
+      chunkStart = index + 1;
+      continue;
+    }
+
+    if (char === "\"") {
+      result = appendPreviewSlice(result, text.slice(chunkStart, index), maxChars);
+      return result;
+    }
+  }
+
+  return result;
+}
+
+function appendPreviewSlice(
+  current: string,
+  next: string,
+  maxChars: number,
+): string {
+  if (current.length >= maxChars || next.length === 0) {
+    return current;
+  }
+  return current + next.slice(0, maxChars - current.length);
+}
+
+function decodeJsonEscape(escaped: string, unicodeDigits: string): string {
+  switch (escaped) {
+    case "\"":
+    case "\\":
+    case "/":
+      return escaped;
+    case "b":
+      return "\b";
+    case "f":
+      return "\f";
+    case "n":
+      return "\n";
+    case "r":
+      return "\r";
+    case "t":
+      return "\t";
+    case "u": {
+      const codePoint = Number.parseInt(unicodeDigits, 16);
+      return Number.isFinite(codePoint) ? String.fromCharCode(codePoint) : "";
+    }
+    default:
+      return escaped;
+  }
 }
 
 function summarizeName(content: string): string {

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -1208,7 +1208,8 @@ export class CodexAdapter implements Adapter, V2Adapter {
     };
     try {
       await this.scanJsonlRawLines(filePath, (rawLine, index, meta) => {
-        if (rawLineHasType(rawLine, "session_meta")) {
+        const envelopeType = extractJsonStringFieldFromBuffer(rawLine, "type");
+        if (envelopeType === "session_meta") {
           const parsed = parseSmallJsonlLine(rawLine);
           const payload = asObject(parsed?.payload);
           if (payload) {
@@ -1224,42 +1225,46 @@ export class CodexAdapter implements Adapter, V2Adapter {
             return;
           }
 
-          const lineText = rawLineToString(rawLine);
-          const payloadStart = lineText.indexOf("\"payload\":");
-          adoptSessionId(extractJsonStringField(lineText, "id", payloadStart));
-          sessionTimestamp = extractJsonStringField(lineText, "timestamp", payloadStart) || sessionTimestamp;
-          cwd = extractJsonStringField(lineText, "cwd", payloadStart) || cwd;
-          gitRemote = extractJsonStringField(lineText, "repository_url", payloadStart) || gitRemote;
-          branch = extractJsonStringField(lineText, "branch", payloadStart) || branch;
-          parentThreadId = extractJsonStringField(lineText, "forked_from_id", payloadStart) || parentThreadId;
+          const payloadStart = findJsonFieldValueStartInBuffer(rawLine, "payload");
+          const gitStart = findJsonFieldValueStartInBuffer(rawLine, "git", payloadStart);
+          const sourceStart = findJsonFieldValueStartInBuffer(rawLine, "source", payloadStart);
+          const subagentStart = findJsonFieldValueStartInBuffer(rawLine, "subagent", sourceStart);
+          const threadSpawnStart = findJsonFieldValueStartInBuffer(rawLine, "thread_spawn", subagentStart);
+          adoptSessionId(extractJsonStringFieldFromBuffer(rawLine, "id", payloadStart));
+          sessionTimestamp = extractJsonStringFieldFromBuffer(rawLine, "timestamp", payloadStart) || sessionTimestamp;
+          cwd = extractJsonStringFieldFromBuffer(rawLine, "cwd", payloadStart) || cwd;
+          gitRemote = extractJsonStringFieldFromBuffer(rawLine, "repository_url", gitStart) || gitRemote;
+          branch = extractJsonStringFieldFromBuffer(rawLine, "branch", gitStart) || branch;
+          parentThreadId =
+            extractJsonStringFieldFromBuffer(rawLine, "parent_thread_id", threadSpawnStart) ||
+            extractJsonStringFieldFromBuffer(rawLine, "forked_from_id", payloadStart) ||
+            parentThreadId;
+          agentNickname = extractJsonStringFieldFromBuffer(rawLine, "agent_nickname", threadSpawnStart) || agentNickname;
           return;
         }
 
-        if (rawLineHasType(rawLine, "turn_context")) {
+        if (envelopeType === "turn_context") {
           currentTurn = currentTurn < 0 ? 1 : currentTurn + 1;
-          const lineText = rawLineToString(rawLine);
-          const payloadStart = lineText.indexOf("\"payload\":");
-          cwd = extractJsonStringField(lineText, "cwd", payloadStart) || cwd;
-          currentModel = extractJsonStringField(lineText, "model", payloadStart) || currentModel;
+          const payloadStart = findJsonFieldValueStartInBuffer(rawLine, "payload");
+          cwd = extractJsonStringFieldFromBuffer(rawLine, "cwd", payloadStart) || cwd;
+          currentModel = extractJsonStringFieldFromBuffer(rawLine, "model", payloadStart) || currentModel;
           return;
         }
 
-        if (rawLineHasType(rawLine, "compacted")) {
+        if (envelopeType === "compacted") {
           const parsed = parseSmallJsonlLine(rawLine);
           const payload = asObject(parsed?.payload);
-          const lineText = payload ? "" : rawLineToString(rawLine);
-          const payloadStart = lineText ? lineText.indexOf("\"payload\":") : -1;
-          const replacementStart = lineText.indexOf("\"replacement_history\"", payloadStart);
-          const payloadHeader = replacementStart >= 0
-            ? lineText.slice(0, replacementStart)
-            : lineText;
-          const timestamp = asString(parsed?.timestamp) || extractJsonStringField(lineText, "timestamp") || fallbackTimestamp;
+          const payloadStart = payload ? -1 : findJsonFieldValueStartInBuffer(rawLine, "payload");
+          const timestamp =
+            asString(parsed?.timestamp) ||
+            extractJsonStringFieldFromBuffer(rawLine, "timestamp") ||
+            fallbackTimestamp;
           const payloadId =
             asString(payload?.id) ||
-            extractJsonStringField(payloadHeader, "id", payloadStart);
+            extractJsonStringFieldFromBuffer(rawLine, "id", payloadStart);
           const turnId =
             asString(payload?.turn_id) ||
-            extractJsonStringField(payloadHeader, "turn_id", payloadStart);
+            extractJsonStringFieldFromBuffer(rawLine, "turn_id", payloadStart);
           addSegment(
             stableHash(
               sessionId,
@@ -1276,12 +1281,12 @@ export class CodexAdapter implements Adapter, V2Adapter {
           return;
         }
 
-        if (!rawLineHasType(rawLine, "response_item")) {
+        if (envelopeType !== "response_item") {
           return;
         }
 
         const lineText = rawLineToString(rawLine);
-        const payloadStart = lineText.indexOf("\"payload\":");
+        const payloadStart = findJsonFieldValueStart(lineText, "payload");
         if (payloadStart < 0) {
           return;
         }
@@ -1700,10 +1705,6 @@ function stableHash(...parts: string[]): string {
     .digest("hex");
 }
 
-function rawLineHasType(rawLine: Buffer, type: string): boolean {
-  return rawLine.indexOf(`"type":"${type}"`) >= 0;
-}
-
 function rawLineToString(rawLine: Buffer): string {
   return rawLine.toString("utf8");
 }
@@ -1726,49 +1727,188 @@ function extractJsonStringField(
   field: string,
   fromIndex = 0,
 ): string {
-  const start = Math.max(0, fromIndex);
-  const keyIndex = text.indexOf(`"${field}":`, start);
-  if (keyIndex < 0) {
-    return "";
-  }
-
-  let valueIndex = keyIndex + field.length + 3;
-  while (valueIndex < text.length && /\s/.test(text[valueIndex])) {
-    valueIndex += 1;
-  }
-  if (text[valueIndex] !== "\"") {
+  const valueIndex = findJsonFieldValueStart(text, field, fromIndex);
+  if (valueIndex < 0 || text[valueIndex] !== "\"") {
     return "";
   }
 
   return extractJsonStringPreview(text, valueIndex);
 }
 
+function extractJsonStringFieldFromBuffer(
+  rawLine: Buffer,
+  field: string,
+  objectStart = 0,
+): string {
+  const valueIndex = findJsonFieldValueStartInBuffer(rawLine, field, objectStart);
+  if (valueIndex < 0 || rawLine[valueIndex] !== 34) {
+    return "";
+  }
+
+  return extractJsonStringPreviewFromBuffer(rawLine, valueIndex);
+}
+
+// Discovery only needs shallow envelope fields. These scanners honor JSON
+// strings, nesting, whitespace, and key order without expanding large payloads.
+function findJsonFieldValueStart(
+  text: string,
+  field: string,
+  objectStart = 0,
+): number {
+  if (objectStart < 0) {
+    return -1;
+  }
+
+  let start = skipJsonWhitespace(text, Math.max(0, objectStart));
+  if (text[start] !== "{") {
+    return -1;
+  }
+
+  let depth = 0;
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "\"") {
+      if (depth !== 1) {
+        const skipped = skipJsonString(text, index);
+        if (skipped < 0) {
+          return -1;
+        }
+        index = skipped;
+        continue;
+      }
+
+      const key = readJsonStringToken(text, index);
+      if (!key) {
+        return -1;
+      }
+      const colonIndex = skipJsonWhitespace(text, key.nextIndex);
+      if (text[colonIndex] === ":") {
+        const valueIndex = skipJsonWhitespace(text, colonIndex + 1);
+        if (key.value === field) {
+          return valueIndex;
+        }
+      }
+      index = key.nextIndex - 1;
+      continue;
+    }
+
+    if (char === "{" || char === "[") {
+      depth += 1;
+      continue;
+    }
+    if (char === "}" || char === "]") {
+      depth -= 1;
+      if (depth <= 0) {
+        return -1;
+      }
+    }
+  }
+
+  return -1;
+}
+
+function findJsonFieldValueStartInBuffer(
+  rawLine: Buffer,
+  field: string,
+  objectStart = 0,
+): number {
+  if (objectStart < 0) {
+    return -1;
+  }
+
+  let start = skipJsonWhitespaceInBuffer(rawLine, Math.max(0, objectStart));
+  if (rawLine[start] !== 123) {
+    return -1;
+  }
+
+  let depth = 0;
+  for (let index = start; index < rawLine.length; index += 1) {
+    const byte = rawLine[index];
+    if (byte === 34) {
+      if (depth !== 1) {
+        const skipped = skipJsonStringInBuffer(rawLine, index);
+        if (skipped < 0) {
+          return -1;
+        }
+        index = skipped;
+        continue;
+      }
+
+      const key = readJsonStringTokenFromBuffer(rawLine, index);
+      if (!key) {
+        return -1;
+      }
+      const colonIndex = skipJsonWhitespaceInBuffer(rawLine, key.nextIndex);
+      if (rawLine[colonIndex] === 58) {
+        const valueIndex = skipJsonWhitespaceInBuffer(rawLine, colonIndex + 1);
+        if (key.value === field) {
+          return valueIndex;
+        }
+      }
+      index = key.nextIndex - 1;
+      continue;
+    }
+
+    if (byte === 123 || byte === 91) {
+      depth += 1;
+      continue;
+    }
+    if (byte === 125 || byte === 93) {
+      depth -= 1;
+      if (depth <= 0) {
+        return -1;
+      }
+    }
+  }
+
+  return -1;
+}
+
 function extractMessageContentPreview(text: string, payloadStart: number): string {
-  const contentIndex = text.indexOf("\"content\":", payloadStart);
+  const contentIndex = findJsonFieldValueStart(text, "content", payloadStart);
   if (contentIndex < 0) {
     return "";
   }
 
-  let valueIndex = contentIndex + "\"content\":".length;
-  while (valueIndex < text.length && /\s/.test(text[valueIndex])) {
-    valueIndex += 1;
+  if (text[contentIndex] === "\"") {
+    return extractJsonStringPreview(text, contentIndex);
   }
 
-  if (text[valueIndex] === "\"") {
-    return extractJsonStringPreview(text, valueIndex);
-  }
-
-  const textIndex = text.indexOf("\"text\":", contentIndex);
+  const textIndex = findJsonFieldValueStartDeep(text, "text", contentIndex);
   if (textIndex >= 0) {
-    return extractJsonStringField(text, "text", textIndex);
+    return text[textIndex] === "\"" ? extractJsonStringPreview(text, textIndex) : "";
   }
 
-  const nestedContentIndex = text.indexOf("\"content\":", contentIndex + 1);
+  const nestedContentIndex = findJsonFieldValueStartDeep(text, "content", contentIndex + 1);
   if (nestedContentIndex >= 0) {
-    return extractJsonStringField(text, "content", nestedContentIndex);
+    return text[nestedContentIndex] === "\"" ? extractJsonStringPreview(text, nestedContentIndex) : "";
   }
 
   return "";
+}
+
+function findJsonFieldValueStartDeep(
+  text: string,
+  field: string,
+  fromIndex = 0,
+): number {
+  for (let index = Math.max(0, fromIndex); index < text.length; index += 1) {
+    if (text[index] !== "\"") {
+      continue;
+    }
+
+    const key = readJsonStringToken(text, index);
+    if (!key) {
+      return -1;
+    }
+    const colonIndex = skipJsonWhitespace(text, key.nextIndex);
+    if (text[colonIndex] === ":" && key.value === field) {
+      return skipJsonWhitespace(text, colonIndex + 1);
+    }
+    index = key.nextIndex - 1;
+  }
+
+  return -1;
 }
 
 function extractJsonStringPreview(
@@ -1776,6 +1916,26 @@ function extractJsonStringPreview(
   quoteIndex: number,
   maxChars = 240,
 ): string {
+  return readJsonStringToken(text, quoteIndex, maxChars)?.value ?? "";
+}
+
+function extractJsonStringPreviewFromBuffer(
+  rawLine: Buffer,
+  quoteIndex: number,
+  maxChars = 240,
+): string {
+  return readJsonStringTokenFromBuffer(rawLine, quoteIndex, maxChars)?.value ?? "";
+}
+
+function readJsonStringToken(
+  text: string,
+  quoteIndex: number,
+  maxChars = 240,
+): { value: string; nextIndex: number } | null {
+  if (text[quoteIndex] !== "\"") {
+    return null;
+  }
+
   let result = "";
   let chunkStart = quoteIndex + 1;
   for (let index = quoteIndex + 1; index < text.length; index += 1) {
@@ -1793,11 +1953,97 @@ function extractJsonStringPreview(
 
     if (char === "\"") {
       result = appendPreviewSlice(result, text.slice(chunkStart, index), maxChars);
-      return result;
+      return { value: result, nextIndex: index + 1 };
     }
   }
 
-  return result;
+  return null;
+}
+
+function readJsonStringTokenFromBuffer(
+  rawLine: Buffer,
+  quoteIndex: number,
+  maxChars = 240,
+): { value: string; nextIndex: number } | null {
+  if (rawLine[quoteIndex] !== 34) {
+    return null;
+  }
+
+  let result = "";
+  let chunkStart = quoteIndex + 1;
+  for (let index = quoteIndex + 1; index < rawLine.length; index += 1) {
+    const byte = rawLine[index];
+    if (byte === 92) {
+      result = appendPreviewSlice(result, rawLine.toString("utf8", chunkStart, index), maxChars);
+      const escaped = rawLine[index + 1] ?? 0;
+      if (result.length < maxChars) {
+        result += decodeJsonEscape(
+          String.fromCharCode(escaped),
+          rawLine.toString("ascii", index + 2, index + 6),
+        );
+      }
+      index += escaped === 117 ? 5 : 1;
+      chunkStart = index + 1;
+      continue;
+    }
+
+    if (byte === 34) {
+      result = appendPreviewSlice(result, rawLine.toString("utf8", chunkStart, index), maxChars);
+      return { value: result, nextIndex: index + 1 };
+    }
+  }
+
+  return null;
+}
+
+function skipJsonString(text: string, quoteIndex: number): number {
+  for (let index = quoteIndex + 1; index < text.length; index += 1) {
+    const char = text[index];
+    if (char === "\\") {
+      index += 1;
+      continue;
+    }
+    if (char === "\"") {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function skipJsonStringInBuffer(rawLine: Buffer, quoteIndex: number): number {
+  for (let index = quoteIndex + 1; index < rawLine.length; index += 1) {
+    const byte = rawLine[index];
+    if (byte === 92) {
+      index += 1;
+      continue;
+    }
+    if (byte === 34) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function skipJsonWhitespace(text: string, index: number): number {
+  let cursor = index;
+  while (cursor < text.length && /\s/.test(text[cursor])) {
+    cursor += 1;
+  }
+  return cursor;
+}
+
+function skipJsonWhitespaceInBuffer(rawLine: Buffer, index: number): number {
+  let cursor = index;
+  while (cursor < rawLine.length) {
+    const byte = rawLine[cursor];
+    if (byte !== 32 && byte !== 9 && byte !== 10 && byte !== 13) {
+      break;
+    }
+    cursor += 1;
+  }
+  return cursor;
 }
 
 function appendPreviewSlice(

--- a/src/pipeline/ingest-worker.ts
+++ b/src/pipeline/ingest-worker.ts
@@ -80,6 +80,7 @@ export type WorkerAdapterSnapshot = {
 export type WorkerLoadConversationRequest = {
   ref: ConversationRef;
   adapter: WorkerAdapterSnapshot;
+  discoveryState?: DiscoveryCacheState | null;
 };
 
 export type WorkerFindChangedRequest = {
@@ -716,6 +717,9 @@ async function loadConversationAndNotify(
     adapter.adapterId,
     adapter.adapterConfig,
   ) as unknown as V2Adapter;
+  if (request.discoveryState && isDiscoveryCacheCapableAdapter(created)) {
+    created.importDiscoveryState(request.discoveryState);
+  }
   if (typeof created.loadConversation !== "function") {
     throw new Error(`adapter ${adapter.adapterId} does not support loadConversation`);
   }
@@ -901,6 +905,7 @@ function parseLoadConversationParams(
           : {}),
       },
     },
+    discoveryState: parseDiscoveryCacheState(value.discoveryState),
   };
 }
 

--- a/src/pipeline/ingest.ts
+++ b/src/pipeline/ingest.ts
@@ -196,6 +196,10 @@ export async function ingestOne(
             {
               ref,
               adapter: workerSnapshot,
+              discoveryState: discoveryStateForSource(
+                discoveryStateSnapshot ?? discoverySummary.state,
+                ref.sourcePath,
+              ),
             },
             {
               timeoutMs: loadConversationTimeoutMs,
@@ -407,6 +411,18 @@ function resolveWorkerLoadSnapshot(
   }
 
   return snapshot;
+}
+
+function discoveryStateForSource(
+  state: DiscoveryCacheState | null,
+  sourcePath: string,
+): DiscoveryCacheState | null {
+  if (!state) {
+    return null;
+  }
+
+  const sources = state.sources.filter((source) => source.sourcePath === sourcePath);
+  return sources.length > 0 ? { sources } : null;
 }
 
 function restoreAdapterDiscoveryState(

--- a/test/codex-reference-adapter.test.ts
+++ b/test/codex-reference-adapter.test.ts
@@ -181,6 +181,48 @@ describe("CodexAdapter v2 reference contract", () => {
     expect(compacted!.conversation.endedAt).toBe("2026-03-26T10:05:01.000Z");
     expect(computeBundleHash(compacted!)).toBe(computeBundleHash(fullParsed));
   });
+
+  test("discovery indexing tolerates formatted JSON and reordered envelope keys", async () => {
+    const codexHome = makeCodexHome([
+      {
+        relativePath: "sessions/2026/03/27/rollout-formatted-envelope.jsonl",
+        contents: formattedEnvelopeFixture(),
+      },
+    ]);
+
+    const coldAdapter = new CodexAdapter(codexHome);
+    const refs = await coldAdapter.findChanged({ kind: "startup-scan" });
+    expect(refs).toHaveLength(2);
+    expect(refs[0]).toMatchObject({
+      id: "formatted-thread",
+      adapterId: "codex",
+    });
+
+    const compactedRef = refs.find((ref) => ref.id !== "formatted-thread");
+    expect(compactedRef).toBeDefined();
+
+    const state = coldAdapter.exportDiscoveryState();
+    expect(state.sources[0]?.payload).toMatchObject({
+      rootName: "Formatted root name",
+      cwd: "/tmp/formatted",
+      branch: "format-main",
+      gitRemote: "git@example.com:formatted/repo.git",
+    });
+
+    const warmAdapter = new CodexAdapter(codexHome);
+    warmAdapter.importDiscoveryState(state);
+    const compacted = await warmAdapter.loadConversation(compactedRef!);
+    const fullParsed = await loadFullParsedBundle(coldAdapter, compactedRef!);
+
+    expect(compacted).not.toBeNull();
+    expect(compacted!.conversation.name).toBe("Formatted root name");
+    expect(compacted!.conversation.relationship).toBe("compacted");
+    expect(compacted!.messages[0]).toMatchObject({
+      role: "user",
+      content: "Formatted compacted history",
+    });
+    expect(computeBundleHash(compacted!)).toBe(computeBundleHash(fullParsed));
+  });
 });
 
 function makeCodexHome(files: Array<{ relativePath: string; contents: string }>): string {
@@ -528,5 +570,16 @@ function delayedNameFixture(): string {
         content: [{ type: "output_text", text: "Continuing after compaction." }],
       },
     }),
+  ].join("\n");
+}
+
+function formattedEnvelopeFixture(): string {
+  return [
+    '{ "payload" : { "git" : { "branch" : "format-main", "repository_url" : "git@example.com:formatted/repo.git" }, "cwd" : "/tmp/formatted", "id" : "formatted-thread", "timestamp" : "2026-03-27T10:00:00.000Z" }, "timestamp" : "2026-03-27T10:00:00.000Z", "type" : "session_meta" }',
+    '{ "payload" : { "cwd" : "/tmp/formatted", "model" : "gpt-format", "turn_id" : "turn-1" }, "timestamp" : "2026-03-27T10:00:01.000Z", "type" : "turn_context" }',
+    '{ "payload" : { "content" : [ { "text" : "Formatted root name", "type" : "input_text" } ], "role" : "user", "type" : "message" }, "timestamp" : "2026-03-27T10:00:02.000Z", "type" : "response_item" }',
+    '{ "payload" : { "content" : [ { "text" : "Root response", "type" : "output_text" } ], "model" : "gpt-format", "role" : "assistant", "type" : "message" }, "timestamp" : "2026-03-27T10:00:03.000Z", "type" : "response_item" }',
+    '{ "payload" : { "replacement_history" : [ { "content" : [ { "text" : "Formatted compacted history", "type" : "input_text" } ], "role" : "user", "type" : "message" } ], "turn_id" : "compact-turn" }, "timestamp" : "2026-03-27T10:05:00.000Z", "type" : "compacted" }',
+    '{ "payload" : { "content" : [ { "text" : "Continuing formatted thread", "type" : "output_text" } ], "model" : "gpt-format", "role" : "assistant", "type" : "message" }, "timestamp" : "2026-03-27T10:05:01.000Z", "type" : "response_item" }',
   ].join("\n");
 }

--- a/test/codex-reference-adapter.test.ts
+++ b/test/codex-reference-adapter.test.ts
@@ -3,6 +3,8 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs"
 import { tmpdir } from "os";
 import { dirname, join } from "path";
 import { CodexAdapter } from "../src/adapters/codex";
+import type { ConversationBundle, ConversationRef } from "../src/contracts/conversations";
+import { computeBundleHash } from "../src/db/bundle";
 
 const SIMPLE_FIXTURE = join(process.cwd(), "test/fixtures/codex/2026-02-21T12-48-43-testcodex.jsonl");
 const tempRoots: string[] = [];
@@ -146,6 +148,39 @@ describe("CodexAdapter v2 reference contract", () => {
       },
     ]);
   });
+
+  test("cached compacted loads retain the root name when the first user appears after segment detection", async () => {
+    const codexHome = makeCodexHome([
+      {
+        relativePath: "sessions/2026/03/26/rollout-delayed-name.jsonl",
+        contents: delayedNameFixture(),
+      },
+    ]);
+
+    const coldAdapter = new CodexAdapter(codexHome);
+    const refs = await coldAdapter.findChanged({ kind: "startup-scan" });
+    expect(refs).toHaveLength(2);
+
+    const compactedRef = refs.find((ref) => ref.id !== "delayed-name-thread");
+    expect(compactedRef).toBeDefined();
+
+    const state = coldAdapter.exportDiscoveryState();
+    expect(state.sources[0]?.payload).toMatchObject({
+      rootName: "Name this conversation from the delayed user turn",
+    });
+
+    const warmAdapter = new CodexAdapter(codexHome);
+    warmAdapter.importDiscoveryState(state);
+    const compacted = await warmAdapter.loadConversation(compactedRef!);
+    const fullParsed = await loadFullParsedBundle(coldAdapter, compactedRef!);
+
+    expect(compacted).not.toBeNull();
+    expect(compacted!.conversation.name).toBe("Name this conversation from the delayed user turn");
+    expect(compacted!.conversation.relationship).toBe("compacted");
+    expect(compacted!.conversation.startedAt).toBe("2026-03-26T10:05:00.000Z");
+    expect(compacted!.conversation.endedAt).toBe("2026-03-26T10:05:01.000Z");
+    expect(computeBundleHash(compacted!)).toBe(computeBundleHash(fullParsed));
+  });
 });
 
 function makeCodexHome(files: Array<{ relativePath: string; contents: string }>): string {
@@ -159,6 +194,37 @@ function makeCodexHome(files: Array<{ relativePath: string; contents: string }>)
   }
 
   return root;
+}
+
+async function loadFullParsedBundle(
+  adapter: CodexAdapter,
+  ref: ConversationRef,
+): Promise<ConversationBundle> {
+  const harness = adapter as unknown as {
+    buildFileModel(filePath: string): Promise<unknown | null>;
+    resolveBase(model: unknown): Promise<unknown>;
+    resolveConversationGit(model: unknown): unknown;
+    buildBundle(
+      model: unknown,
+      base: unknown,
+      git: unknown,
+      index: number,
+    ): ConversationBundle;
+  };
+  const model = await harness.buildFileModel(ref.sourcePath);
+  if (!model) {
+    throw new Error(`expected full Codex model for ${ref.sourcePath}`);
+  }
+
+  const segments = (model as { segments: Array<{ id: string }> }).segments;
+  const segmentIndex = segments.findIndex((segment) => segment.id === ref.id);
+  if (segmentIndex < 0) {
+    throw new Error(`expected full Codex model to include segment ${ref.id}`);
+  }
+
+  const base = await harness.resolveBase(model);
+  const git = harness.resolveConversationGit(model);
+  return harness.buildBundle(model, base, git, segmentIndex);
 }
 
 function parentFixture(): string {
@@ -384,6 +450,82 @@ function childFixture(): string {
         role: "assistant",
         model: "gpt-5.4-mini",
         content: [{ type: "output_text", text: "The patch looks correct." }],
+      },
+    }),
+  ].join("\n");
+}
+
+function delayedNameFixture(): string {
+  return [
+    JSON.stringify({
+      timestamp: "2026-03-26T10:00:00.000Z",
+      type: "session_meta",
+      payload: {
+        id: "delayed-name-thread",
+        timestamp: "2026-03-26T10:00:00.000Z",
+        cwd: "/tmp/project",
+        originator: "Codex Desktop",
+        source: "vscode",
+      },
+    }),
+    JSON.stringify({
+      timestamp: "2026-03-26T10:00:01.000Z",
+      type: "turn_context",
+      payload: {
+        turn_id: "turn-1",
+        cwd: "/tmp/project",
+        model: "gpt-5.4",
+      },
+    }),
+    JSON.stringify({
+      timestamp: "2026-03-26T10:00:02.000Z",
+      type: "response_item",
+      payload: {
+        type: "reasoning",
+        summary: [],
+        encrypted_content: "gAAAAA-before-user",
+      },
+    }),
+    JSON.stringify({
+      timestamp: "2026-03-26T10:00:03.000Z",
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "Name this conversation from the delayed user turn" }],
+      },
+    }),
+    JSON.stringify({
+      timestamp: "2026-03-26T10:00:04.000Z",
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "assistant",
+        model: "gpt-5.4",
+        content: [{ type: "output_text", text: "I will keep that name." }],
+      },
+    }),
+    JSON.stringify({
+      timestamp: "2026-03-26T10:05:00.000Z",
+      type: "compacted",
+      payload: {
+        replacement_history: [
+          {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "Compacted follow-up" }],
+          },
+        ],
+      },
+    }),
+    JSON.stringify({
+      timestamp: "2026-03-26T10:05:01.000Z",
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "assistant",
+        model: "gpt-5.4",
+        content: [{ type: "output_text", text: "Continuing after compaction." }],
       },
     }),
   ].join("\n");


### PR DESCRIPTION
## Summary
- Store Codex segment byte offsets and file metadata in the adapter discovery cache.
- Pass per-source discovery state into worker conversation loads so compacted refs can load targeted byte ranges instead of rebuilding the full JSONL file model.
- Replace discovery indexing with a raw JSONL scanner that avoids expanding huge compacted replacement histories during ref discovery.
- Add regression coverage comparing cached targeted compacted loads against full-file parse bundle hashes.

## Validation
- `bun run typecheck`
- `bun run test test/codex-reference-adapter.test.ts`

## Notes
- Draft PR only. Do not merge yet.
- Real repro: 573 MB Codex JSONL with a 17 MB compacted replacement_history line containing embedded base64 images. Post-fix targeted worker loads measured around 190-201 MB RSS in the contained repro.